### PR TITLE
Allow to limit to a number of frames

### DIFF
--- a/src/native-state-drm.cpp
+++ b/src/native-state-drm.cpp
@@ -24,6 +24,7 @@
  */
 #include "native-state-drm.h"
 #include "log.h"
+#include <fcntl.h>
 
 /******************
  * Public methods *
@@ -197,27 +198,7 @@ NativeStateDRM::init_gbm()
 bool
 NativeStateDRM::init()
 {
-    // TODO: Replace this with something that explicitly probes for the loaded
-    // driver (udev?).
-    static const char* drm_modules[] = {
-        "i915",
-        "nouveau",
-        "radeon",
-        "vmgfx",
-        "omapdrm",
-        "exynos"
-    };
-
-    unsigned int num_modules(sizeof(drm_modules)/sizeof(drm_modules[0]));
-    for (unsigned int m = 0; m < num_modules; m++) {
-        fd_ = drmOpen(drm_modules[m], 0);
-        if (fd_ < 0) {
-            Log::debug("Failed to open DRM module '%s'\n", drm_modules[m]);
-            continue;
-        }
-        Log::debug("Opened DRM module '%s'\n", drm_modules[m]);
-        break;
-    }
+    fd_ = open("/dev/dri/card0", O_RDWR);
 
     if (fd_ < 0) {
         Log::error("Failed to find a suitable DRM device\n");

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -43,10 +43,12 @@ name(nam), value(val), default_value(val), description(desc), set(false)
 Scene::Scene(Canvas &pCanvas, const string &name) :
     canvas_(pCanvas), name_(name),
     startTime_(0), lastUpdateTime_(0), currentFrame_(0),
-    running_(0), duration_(0)
+    running_(0), duration_(0), nframes_(0)
 {
     options_["duration"] = Scene::Option("duration", "10.0",
                                          "The duration of each benchmark in seconds");
+    options_["nframes"] = Scene::Option("nframes", "",
+                                         "The number of frames to render");
     options_["vertex-precision"] = Scene::Option("vertex-precision",
                                                  "default,default,default,default",
                                                  "The precision values for the vertex shader (\"int,float,sampler2d,samplercube\")");
@@ -96,6 +98,7 @@ bool
 Scene::setup()
 {
     duration_ = Util::fromString<double>(options_["duration"].value);
+    nframes_ = Util::fromString<unsigned>(options_["nframes"].value);
 
     ShaderSource::default_precision(
             ShaderSource::Precision(options_["vertex-precision"].value),
@@ -131,6 +134,9 @@ Scene::update()
     lastUpdateTime_ = current_time;
 
     if (elapsed_time >= duration_)
+        running_ = false;
+
+    if (nframes_ > 0 && currentFrame_ >= nframes_)
         running_ = false;
 }
 

--- a/src/scene.h
+++ b/src/scene.h
@@ -234,6 +234,7 @@ protected:
     unsigned currentFrame_;
     bool running_;
     double duration_;      // Duration of run in seconds
+    unsigned nframes_;
 };
 
 /*


### PR DESCRIPTION
This can be useful to run "fixed task size" benchmarks, allowing perf
stat to report comparable results.

Signed-off-by: Marc-André Lureau marcandre.lureau@gmail.com
