### PR TITLE
Fix C++11 build error

### DIFF
--- a/src/native-state-x11.cpp
+++ b/src/native-state-x11.cpp
@@ -60,7 +60,7 @@ NativeStateX11::display()
 bool
 NativeStateX11::create_window(WindowProperties const& properties)
 {
-    static const char *win_name("glmark2 "GLMARK_VERSION);
+    static const char *win_name("glmark2 " GLMARK_VERSION);
 
     if (!xdpy_) {
         Log::error("Error: X11 Display has not been initialized!\n");


### PR DESCRIPTION
C++11 requires whitespace between a string literal and a macro, otherwise it's looked up as a user-defined literal. Adding the whitespace makes it valid in any version of C++.