### PR TITLE
Fix compilation errors with recent g++ versions

### DIFF
--- a/src/image-reader.cpp
+++ b/src/image-reader.cpp
@@ -120,7 +120,7 @@ PNGReader::init(const std::string& filename)
 
     Log::debug("Reading PNG file %s\n", filename.c_str());
 
-    const std::auto_ptr<std::istream> is_ptr(Util::get_resource(filename));
+    const std::unique_ptr<std::istream> is_ptr(Util::get_resource(filename));
     if (!(*is_ptr)) {
         Log::error("Cannot open file %s!\n", filename.c_str());
         return false;

--- a/src/libmatrix/shader-source.cc
+++ b/src/libmatrix/shader-source.cc
@@ -34,7 +34,7 @@ ShaderSource::default_precision_(ShaderSource::ShaderTypeUnknown + 1);
 bool
 ShaderSource::load_file(const std::string& filename, std::string& str)
 {
-    std::auto_ptr<std::istream> is_ptr(Util::get_resource(filename));
+    std::unique_ptr<std::istream> is_ptr(Util::get_resource(filename));
     std::istream& inputFile(*is_ptr);
 
     if (!inputFile)

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -361,7 +361,7 @@ Model::load_3ds(const std::string &filename)
 
     Log::debug("Loading model from 3ds file '%s'\n", filename.c_str());
 
-    const std::auto_ptr<std::istream> input_file_ptr(Util::get_resource(filename));
+    const std::unique_ptr<std::istream> input_file_ptr(Util::get_resource(filename));
     std::istream& input_file(*input_file_ptr);
 
     if (!input_file) {
@@ -681,7 +681,7 @@ Model::load_obj(const std::string &filename)
 {
     Log::debug("Loading model from obj file '%s'\n", filename.c_str());
 
-    const std::auto_ptr<std::istream> input_file_ptr(Util::get_resource(filename));
+    const std::unique_ptr<std::istream> input_file_ptr(Util::get_resource(filename));
     std::istream& inputFile(*input_file_ptr);
     if (!inputFile)
     {

--- a/src/native-state-x11.cpp
+++ b/src/native-state-x11.cpp
@@ -60,7 +60,7 @@ NativeStateX11::display()
 bool
 NativeStateX11::create_window(WindowProperties const& properties)
 {
-    static const char *win_name("glmark2 "GLMARK_VERSION);
+    static const char *win_name("glmark2 " GLMARK_VERSION);
 
     if (!xdpy_) {
         Log::error("Error: X11 Display has not been initialized!\n");

--- a/src/scene-jellyfish.cpp
+++ b/src/scene-jellyfish.cpp
@@ -272,7 +272,7 @@ JellyfishPrivate::load_obj(const std::string &filename)
 {
     Log::debug("Loading model from file '%s'\n", filename.c_str());
 
-    const std::auto_ptr<std::istream> input_file_ptr(Util::get_resource(filename));
+    const std::unique_ptr<std::istream> input_file_ptr(Util::get_resource(filename));
     std::istream& inputFile(*input_file_ptr);
     if (!inputFile)
     {

--- a/wscript
+++ b/wscript
@@ -82,17 +82,17 @@ def configure(ctx):
     # Check required headers
     req_headers = ['stdlib.h', 'string.h', 'unistd.h', 'stdint.h', 'stdio.h', 'jpeglib.h']
     for header in req_headers:
-        ctx.check_cxx(header_name = header, auto_add_header_name = True, mandatory = True)
+        ctx.check_cc(header_name = header, auto_add_header_name = True, mandatory = True)
 
     # Check for required libs
     req_libs = [('m', 'm'), ('jpeg', 'jpeg')]
     for (lib, uselib) in req_libs:
-        ctx.check_cxx(lib = lib, uselib_store = uselib)
+        ctx.check_cc(lib = lib, uselib_store = uselib)
 
     # Check required functions
     req_funcs = [('memset', 'string.h', []) ,('sqrt', 'math.h', ['m'])]
     for func, header, uselib in req_funcs:
-        ctx.check_cxx(function_name = func, header_name = header,
+        ctx.check_cc(function_name = func, header_name = header,
                       uselib = uselib, mandatory = True)
 
     # Check for a supported version of libpng


### PR DESCRIPTION
A bunch of errors are now triggered if using G++ 6.1, due to the use of obsolete features or ambiguous statements. This pull request fixes them.