### PR TITLE
native-state-drm: add tegra driver

### DIFF
--- a/src/native-state-drm.cpp
+++ b/src/native-state-drm.cpp
@@ -201,6 +201,7 @@ NativeStateDRM::init()
     // driver (udev?).
     static const char* drm_modules[] = {
         "i915",
+	"tegra",
         "nouveau",
         "radeon",
         "vmgfx",


### PR DESCRIPTION
This allows glmark2-drm to run on Tegra-powered devices.