### PR TITLE
drm backend pageflip fix

### DIFF
--- a/src/native-state-drm.cpp
+++ b/src/native-state-drm.cpp
@@ -106,6 +106,7 @@ NativeStateDRM::flip()
     FD_ZERO(&fds);
     FD_SET(fd_, &fds);
     drmEventContext evCtx;
+    memset(&evCtx, 0, sizeof(evCtx));
     evCtx.version = DRM_EVENT_CONTEXT_VERSION;
     evCtx.page_flip_handler = page_flip_handler;
 

--- a/src/native-state-drm.cpp
+++ b/src/native-state-drm.cpp
@@ -205,7 +205,9 @@ NativeStateDRM::init()
         "radeon",
         "vmgfx",
         "omapdrm",
-        "exynos"
+        "exynos",
+        "pl111",
+        "vc4",
     };
 
     unsigned int num_modules(sizeof(drm_modules)/sizeof(drm_modules[0]));


### PR DESCRIPTION
This pull request fixes segfaults when built against newer libdrm, and also brings in support for running against 2 more DRM drivers.