### PR TITLE
eglGetPlatformDisplayEXT and DRM device node detection using libudev

### DIFF
--- a/src/gl-state-egl.cpp
+++ b/src/gl-state-egl.cpp
@@ -415,7 +415,23 @@ GLStateEGL::gotValidDisplay()
     if (egl_display_)
         return true;
 
-    egl_display_ = eglGetDisplay(native_display_);
+    Log::debug("Using eglGetPlatformDisplayEXT !\n");
+    PFNEGLGETPLATFORMDISPLAYEXTPROC get_platform_display = NULL;
+    get_platform_display =
+      reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(
+        eglGetProcAddress("eglGetPlatformDisplayEXT")
+      );
+
+    if (get_platform_display != nullptr) {
+        egl_display_ = get_platform_display(
+          GLMARK2_NATIVE_EGL_DISPLAY_ENUM, native_display_, NULL
+        );
+    }
+    
+    /* Just in case get_platform_display failed... */
+    if (!egl_display_)
+        egl_display_ = eglGetDisplay(native_display_);
+
     if (!egl_display_) {
         Log::error("eglGetDisplay() failed with error: 0x%x\n", eglGetError());
         return false;

--- a/src/gl-state-egl.h
+++ b/src/gl-state-egl.h
@@ -24,8 +24,19 @@
 
 #include <vector>
 #include <EGL/egl.h>
+#include <EGL/eglext.h>
 #include "gl-state.h"
 #include "gl-visual-config.h"
+
+#ifdef GLMARK2_USE_X11
+#define GLMARK2_NATIVE_EGL_DISPLAY_ENUM EGL_PLATFORM_X11_KHR
+#elif  GLMARK2_USE_WAYLAND
+#define GLMARK2_NATIVE_EGL_DISPLAY_ENUM EGL_PLATFORM_WAYLAND_KHR
+#elif  GLMARK2_USE_DRM
+#define GLMARK2_NATIVE_EGL_DISPLAY_ENUM EGL_PLATFORM_GBM_KHR
+#elif  GLMARK2_USE_MIR
+#define GLMARK2_NATIVE_EGL_DISPLAY_ENUM EGL_PLATFORM_MIR_KHR
+#endif
 
 class EglConfig
 {

--- a/src/native-state-drm.cpp
+++ b/src/native-state-drm.cpp
@@ -199,9 +199,19 @@ NativeStateDRM::init_gbm()
     return true;
 }
 
+/* Omitting the parameter names is kind of ugly but is the only way
+ * to force G++ to forget about the unused parameters.
+ * Having big warnings during the compilation isn't very nice.
+ * 
+ * These functions will be used as function pointers and should have
+ * the same signature to avoid weird stack related issues.
+ * 
+ * Another way to deal with that issue will be to mark unused parameters
+ * with __attribute__((unused))
+ */
 bool 
 NativeStateDRM::udev_drm_test_virtual
-(UDEV_TEST_FUNC_SIGNATURE(udev, current_device, tested_node_syspath))
+(UDEV_TEST_FUNC_SIGNATURE(,, tested_node_syspath))
 {
     return strstr(tested_node_syspath, "virtual") != NULL;
 }
@@ -217,7 +227,7 @@ NativeStateDRM::udev_drm_test_not_virtual
 
 bool
 NativeStateDRM::udev_drm_test_primary_gpu
-(UDEV_TEST_FUNC_SIGNATURE(udev, current_device, tested_node_syspath))
+(UDEV_TEST_FUNC_SIGNATURE(, current_device,))
 {
 
     bool result = false;

--- a/src/native-state-drm.h
+++ b/src/native-state-drm.h
@@ -32,6 +32,7 @@
 #include <drm.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
+#include <libudev.h>
 
 class NativeStateDRM : public NativeState
 {
@@ -71,10 +72,25 @@ private:
     static void quit_handler(int signum);
     static volatile std::sig_atomic_t should_quit_;
 
+    static char const * drm_primary_gpu_device_node
+    (struct udev * __restrict const udev,
+     struct udev_enumerate * __restrict const dev_enum);
+    
+    static char const * udev_main_gpu_drm_node_path();
+    
+    static int open_using_udev_scan();
+    static int open_using_module_checking();
+    
+    inline static bool is_valid_fd(int fd) {
+        return fd >= 0;
+    }
+
     DRMFBState* fb_get_from_bo(gbm_bo* bo);
     bool init_gbm();
     bool init();
     void cleanup();
+
+
 
     int fd_;
     drmModeRes* resources_;

--- a/src/native-state-drm.h
+++ b/src/native-state-drm.h
@@ -72,19 +72,51 @@ private:
     static void quit_handler(int signum);
     static volatile std::sig_atomic_t should_quit_;
 
-    static char const * drm_primary_gpu_device_node
+    // Udev detection functions
+    #define UDEV_TEST_FUNC_SIGNATURE(udev_identifier, device_identifier, syspath_identifier) \
+      struct udev * __restrict const udev_identifier, \
+      struct udev_device * __restrict const device_identifier, \
+      char const * __restrict syspath_identifier
+    
+    static bool udev_drm_test_virtual(
+        UDEV_TEST_FUNC_SIGNATURE(udev,device,syspath)
+    );
+    
+    static bool udev_drm_test_not_virtual(
+        UDEV_TEST_FUNC_SIGNATURE(udev,device,syspath)
+    );
+    
+    static bool udev_drm_test_primary_gpu(
+        UDEV_TEST_FUNC_SIGNATURE(udev,device,syspath)
+    );
+    
+    static char const * udev_get_node_that_pass_in_enum
     (struct udev * __restrict const udev,
-     struct udev_enumerate * __restrict const dev_enum);
+     struct udev_enumerate * __restrict const dev_enum,
+     bool (* check_function)(UDEV_TEST_FUNC_SIGNATURE(,,))
+    );
     
     static char const * udev_main_gpu_drm_node_path();
     
     static int open_using_udev_scan();
     static int open_using_module_checking();
     
-    inline static bool is_valid_fd(int fd) {
+    inline static bool valid_fd(int fd) {
         return fd >= 0;
     }
 
+    inline static bool valid_drm_node_path
+    (char const * __restrict const provided_node_path)
+    {
+        return provided_node_path != NULL;
+    }
+    
+    inline static bool invalid_drm_node_path
+    (char const * __restrict const provided_node_path)
+    {
+        return !(valid_drm_node_path(provided_node_path));
+    }
+    
     DRMFBState* fb_get_from_bo(gbm_bo* bo);
     bool init_gbm();
     bool init();

--- a/src/wscript_build
+++ b/src/wscript_build
@@ -25,8 +25,8 @@ flavor_sources = {
 flavor_uselibs = {
   'x11-gl' : ['x11', 'gl', 'matrix-gl', 'common-gl'],
   'x11-glesv2' : ['x11', 'egl', 'glesv2', 'matrix-glesv2', 'common-glesv2'],
-  'drm-gl' : ['drm', 'gbm', 'egl', 'gl', 'matrix-gl', 'common-gl'],
-  'drm-glesv2' : ['drm', 'gbm', 'egl', 'glesv2', 'matrix-glesv2', 'common-glesv2'],
+  'drm-gl' : ['drm', 'gbm', 'udev', 'egl', 'gl', 'matrix-gl', 'common-gl'],
+  'drm-glesv2' : ['drm', 'gbm', 'udev', 'egl', 'glesv2', 'matrix-glesv2', 'common-glesv2'],
   'mir-gl' : ['mirclient', 'egl', 'gl', 'matrix-gl', 'common-gl'],
   'mir-glesv2' : ['mirclient', 'egl', 'glesv2', 'matrix-glesv2', 'common-glesv2'],
   'wayland-gl' : ['wayland-client', 'wayland-egl', 'egl', 'gl', 'matrix-gl', 'common-gl'],

--- a/wscript
+++ b/wscript
@@ -112,6 +112,7 @@ def configure(ctx):
                 ('glesv2', 'glesv2', None, list_contains(ctx.options.flavors, 'glesv2$')),
                 ('libdrm','drm', None, list_contains(ctx.options.flavors, 'drm')),
                 ('gbm','gbm', None, list_contains(ctx.options.flavors, 'drm')),
+                ('libudev', 'udev', None, list_contains(ctx.options.flavors, 'drm')),
                 ('mirclient','mirclient', '0.13', list_contains(ctx.options.flavors, 'mir')),
                 ('wayland-client','wayland-client', None, list_contains(ctx.options.flavors, 'wayland')),
                 ('wayland-egl','wayland-egl', None, list_contains(ctx.options.flavors, 'wayland'))]


### PR DESCRIPTION
* Using eglGetPlatformDisplayEXT when possible, before eglGetPlatformDisplay, as that solves issues with some MALI 3D drivers and tends to be the way to go. This is how the DRM implementatikons of  Weston, KWin and Mesa KMSCube do it and it works relatively well. eglGetPlatformDisplay still get used as a fallback, so everything is fine.

* Using UDev to detect the main DRM device node to use, before trying the DRM modules list. This works on desktop systems, on embedded systems and is able to detect whether the device node belongs to a virtual device, or a concrete device, so this should take care of Virtual GEM issues.

This adds a dependency, libudev, which should be available on most systems. SystemD requires it and non SystemD systems still have an implementation of UDev to satisfy programs made for SystemD.

TODO :
Adding an option to let the user define the device node to use, for expert users who know exactly which DRM node they want to try the benchmark on. In such cases, the program should only try to use the node and exit if it couldn't, considering the user knows what he's doing in such cases.