### PR TITLE
Fix build with clang

### DIFF
--- a/src/native-state-drm.cpp
+++ b/src/native-state-drm.cpp
@@ -331,7 +331,7 @@ static int open_using_udev_scan()
     if (!valid_fd(fd)) {
         // %m is GLIBC specific... Maybe use strerror here...
         Log::error("Tried to use '%s' but failed.\nReason : %m",
-                   dev_path);
+                   dev_path.c_str());
     }
     else
         Log::debug("Success!\n");


### PR DESCRIPTION
../src/native-state-drm.cpp:334:20: error: cannot pass object of non-trivial type 'std::__cxx11::basic_string<char>' through variadic function; call will abort at runtime [-Wnon-pod-varargs]
                   dev_path);
                   ^
1 error generated.

Signed-off-by: Khem Raj <raj.khem@gmail.com>