### PR TITLE
Add fbdev-glesv2 flavor with Mali GPU support

### DIFF
--- a/src/gl-state-egl.cpp
+++ b/src/gl-state-egl.cpp
@@ -457,7 +457,11 @@ GLStateEGL::gotValidDisplay()
     /* Just in case get_platform_display failed... */
     if (!egl_display_) {
         Log::debug("Falling back to eglGetDisplay()\n");
+#ifdef HAS_MALI
+        egl_display_ = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+#else
         egl_display_ = eglGetDisplay(native_display_);
+#endif
     }
 
     if (!egl_display_) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,6 +42,8 @@
 #include "native-state-mir.h"
 #elif GLMARK2_USE_WAYLAND
 #include "native-state-wayland.h"
+#elif GLMARK2_USE_FBDEV
+#include "native-state-fbdev.h"
 #endif
 
 #if GLMARK2_USE_EGL
@@ -168,6 +170,8 @@ main(int argc, char *argv[])
     NativeStateMir native_state;
 #elif GLMARK2_USE_WAYLAND
     NativeStateWayland native_state;
+#elif GLMARK2_USE_FBDEV
+    NativeStateFBDEV native_state;
 #endif
 
 #if GLMARK2_USE_EGL

--- a/src/native-state-fbdev.cpp
+++ b/src/native-state-fbdev.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2012 Linaro Limited
+ * Copyright © 2013 Canonical Ltd
+ *
+ * This file is part of the glmark2 OpenGL (ES) 2.0 benchmark.
+ *
+ * glmark2 is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * glmark2 is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * glmark2.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *  Simon Que
+ *  Jesse Barker
+ *  Alexandros Frantzis
+ *  Wladimir J. van der Laan
+ */
+#include "native-state-fbdev.h"
+#include "log.h"
+#include "util.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <linux/fb.h>
+#if HAS_MALI
+#include <EGL/fbdev_window.h>
+#endif
+#ifdef ANDROID
+#define FBDEV_DEV "/dev/graphics/fb"
+#else
+#define FBDEV_DEV "/dev/fb"
+#endif
+
+/******************
+ * Public methods *
+ ******************/
+
+bool
+NativeStateFBDEV::init_display()
+{
+    if (fd == -1)
+        return init();
+    return true;
+}
+
+void*
+NativeStateFBDEV::display()
+{
+    return reinterpret_cast<void*>(fd);
+}
+
+bool
+NativeStateFBDEV::create_window(WindowProperties const& /*properties*/)
+{
+    struct fb_var_screeninfo fb_var;
+    if (fd == -1) {
+        Log::error("Error: display has not been initialized!\n");
+        return false;
+    }
+    if (ioctl(fd, FBIOGET_VSCREENINFO, &fb_var))
+    {
+        Log::error("Error: cannot get variable frame buffer info\n");
+        return false;
+    }
+    winprops.width = fb_var.xres;
+    winprops.height = fb_var.yres;
+    winprops.fullscreen = true;
+    return true;
+}
+
+void*
+NativeStateFBDEV::window(WindowProperties& properties)
+{
+    properties = winprops;
+#ifdef HAS_MALI
+    native_window.height = winprops.height;
+    native_window.width = winprops.width;
+    return reinterpret_cast<void*>(&native_window);
+#else
+    return NULL;
+#endif
+}
+
+void
+NativeStateFBDEV::visible(bool /*visible*/)
+{
+}
+
+bool
+NativeStateFBDEV::should_quit()
+{
+    return should_quit_;
+}
+
+void
+NativeStateFBDEV::flip()
+{
+}
+
+/*******************
+ * Private methods *
+ *******************/
+
+bool
+NativeStateFBDEV::init()
+{
+    std::string devname;
+    int num = 0; /* always fb0 for now */
+
+    devname = std::string(FBDEV_DEV) + Util::toString(num);
+    fd = open(devname.c_str(), O_RDWR);
+    if(fd == -1)
+    {
+        Log::error("Error: Cannot open framebuffer device %s\n", devname.c_str());
+        return false;
+    }
+
+    signal(SIGINT, &NativeStateFBDEV::quit_handler);
+
+    return true;
+}
+
+volatile std::sig_atomic_t NativeStateFBDEV::should_quit_(false);
+
+void
+NativeStateFBDEV::quit_handler(int /*signo*/)
+{
+    should_quit_ = true;
+}
+
+void
+NativeStateFBDEV::cleanup()
+{
+    close(fd);
+    fd = -1;
+}

--- a/src/native-state-fbdev.h
+++ b/src/native-state-fbdev.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2012 Linaro Limited
+ * Copyright © 2013 Canonical Ltd
+ *
+ * This file is part of the glmark2 OpenGL (ES) 2.0 benchmark.
+ *
+ * glmark2 is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * glmark2 is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * glmark2.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *  Simon Que
+ *  Jesse Barker
+ *  Alexandros Frantzis
+ *  Wladimir J. van der Laan
+ */
+#ifndef GLMARK2_NATIVE_STATE_FBDEV_H_
+#define GLMARK2_NATIVE_STATE_FBDEV_H_
+
+#include "native-state.h"
+#include <csignal>
+#include <cstring>
+
+#ifdef HAS_MALI
+#include <EGL/fbdev_window.h>
+#endif
+
+class NativeStateFBDEV : public NativeState
+{
+public:
+    NativeStateFBDEV() :
+        fd(-1) {}
+    ~NativeStateFBDEV() { cleanup(); }
+
+    bool init_display();
+    void* display();
+    bool create_window(WindowProperties const& properties);
+    void* window(WindowProperties& properties);
+    void visible(bool v);
+    bool should_quit();
+    void flip();
+
+private:
+    static void quit_handler(int signum);
+    static volatile std::sig_atomic_t should_quit_;
+    int fd;
+    WindowProperties winprops;
+#ifdef HAS_MALI
+    struct fbdev_window native_window;
+#endif
+    bool init();
+    void cleanup();
+};
+
+#endif /* GLMARK2_NATIVE_STATE_FBDEV_H_ */

--- a/src/wscript_build
+++ b/src/wscript_build
@@ -20,7 +20,8 @@ flavor_sources = {
   'mir-gl' : common_flavor_sources + ['native-state-mir.cpp', 'gl-state-egl.cpp'],
   'mir-glesv2' : common_flavor_sources + ['native-state-mir.cpp', 'gl-state-egl.cpp'],
   'wayland-gl' : common_flavor_sources + ['native-state-wayland.cpp', 'gl-state-egl.cpp'],
-  'wayland-glesv2' : common_flavor_sources + ['native-state-wayland.cpp', 'gl-state-egl.cpp']
+  'wayland-glesv2' : common_flavor_sources + ['native-state-wayland.cpp', 'gl-state-egl.cpp'],
+  'fbdev-glesv2' : common_flavor_sources + ['native-state-fbdev.cpp', 'gl-state-egl.cpp']
 }
 flavor_uselibs = {
   'x11-gl' : ['x11', 'gl', 'matrix-gl', 'common-gl'],
@@ -30,7 +31,8 @@ flavor_uselibs = {
   'mir-gl' : ['mirclient', 'egl', 'gl', 'matrix-gl', 'common-gl'],
   'mir-glesv2' : ['mirclient', 'egl', 'glesv2', 'matrix-glesv2', 'common-glesv2'],
   'wayland-gl' : ['wayland-client', 'wayland-egl', 'egl', 'gl', 'matrix-gl', 'common-gl'],
-  'wayland-glesv2' : ['wayland-client', 'wayland-egl', 'egl', 'glesv2', 'matrix-glesv2', 'common-glesv2']
+  'wayland-glesv2' : ['wayland-client', 'wayland-egl', 'egl', 'glesv2', 'matrix-glesv2', 'common-glesv2'],
+  'fbdev-glesv2' : ['egl', 'glesv2', 'matrix-glesv2', 'common-glesv2']
 }
 flavor_defines = {
   'x11-gl' : ['GLMARK2_USE_X11', 'GLMARK2_USE_GL', 'GLMARK2_USE_GLX'],
@@ -40,7 +42,8 @@ flavor_defines = {
   'mir-gl' : ['GLMARK2_USE_MIR', 'GLMARK2_USE_GL', 'GLMARK2_USE_EGL'],
   'mir-glesv2' : ['GLMARK2_USE_MIR', 'GLMARK2_USE_GLESv2', 'GLMARK2_USE_EGL'],
   'wayland-gl' : ['GLMARK2_USE_WAYLAND', 'GLMARK2_USE_GL', 'GLMARK2_USE_EGL'],
-  'wayland-glesv2' : ['GLMARK2_USE_WAYLAND', 'GLMARK2_USE_GLESv2', 'GLMARK2_USE_EGL']
+  'wayland-glesv2' : ['GLMARK2_USE_WAYLAND', 'GLMARK2_USE_GLESv2', 'GLMARK2_USE_EGL'],
+  'fbdev-glesv2' : ['GLMARK2_USE_FBDEV', 'GLMARK2_USE_GLESv2', 'GLMARK2_USE_EGL', 'MESA_EGL_NO_X11_HEADERS']
 }
 
 includes = ['.', 'scene-ideas', 'scene-terrain']

--- a/wscript
+++ b/wscript
@@ -15,7 +15,8 @@ FLAVORS = {
     'mir-gl' : 'glmark2-mir',
     'mir-glesv2' : 'glmark2-es2-mir',
     'wayland-gl' : 'glmark2-wayland',
-    'wayland-glesv2' : 'glmark2-es2-wayland'
+    'wayland-glesv2' : 'glmark2-es2-wayland',
+    'fbdev-glesv2' : 'glmark2-es2-fbdev'
 }
 FLAVORS_STR = ", ".join(FLAVORS.keys())
 
@@ -42,6 +43,8 @@ def options(opt):
                    help = "a list of flavors to build (%s, all)" % FLAVORS_STR)
     opt.parser.set_default('flavors', [])
 
+    opt.add_option('--for-mali', action='store_true', dest = 'mali',
+                   default = False, help='enable ARM Mali GPU support')
     opt.add_option('--no-debug', action='store_false', dest = 'debug',
                    default = True, help='disable compiler debug information')
     opt.add_option('--no-opt', action='store_false', dest = 'opt',
@@ -132,6 +135,9 @@ def configure(ctx):
     if ctx.options.debug:
         ctx.env.prepend_value('CXXFLAGS', '-g')
     ctx.env.prepend_value('CXXFLAGS', '-std=c++14 -Wall -Wextra -Wnon-virtual-dtor'.split(' '))
+
+    if ctx.options.mali:
+        ctx.env.append_unique('DEFINES','HAS_MALI=1')
 
     ctx.env.HAVE_EXTRAS = False
     if ctx.options.extras_path is not None:


### PR DESCRIPTION
This PR adds a fbdev-glesv2 flavor with Mali support.
Only tested on Amlogic/Rockchip devices with Mail 450/t760 fbdev user-space drivers.

Based on revision 279 by Wladimir J. van der Laan and 282 by Spenser Gilliland
from https://code.launchpad.net/~spenser-gilliland/glmark2/mali-fbdev