### PR TITLE
define EGL_PLATFORM_X11_KHR

### DIFF
--- a/src/gl-state-egl.cpp
+++ b/src/gl-state-egl.cpp
@@ -412,6 +412,7 @@ GLStateEGL::getVisualConfig(GLVisualConfig& vc)
  * GLStateEGL private methods *
  *****************************/
 
+#define EGL_PLATFORM_X11_KHR 0x31D5
 #ifdef GLMARK2_USE_X11
 #define GLMARK2_NATIVE_EGL_DISPLAY_ENUM EGL_PLATFORM_X11_KHR
 #elif  GLMARK2_USE_WAYLAND


### PR DESCRIPTION
There's ERROR when compiling glmark2-es2 on ARM64 board. It was 'EGL_PLATFORM_X11_KHR' was not declared in this scop'.