### PR TITLE
Add meson driver in list of DRM modules

### DIFF
--- a/src/native-state-drm.cpp
+++ b/src/native-state-drm.cpp
@@ -361,6 +361,7 @@ static int open_using_module_checking()
         "exynos",
         "pl111",
         "vc4",
+	"meson",
     };
 
     int fd = -1;


### PR DESCRIPTION
The Amlogic Meson DRM Linux driver is a valid atomic modesetting driver that should be in the modules list.