### PR TITLE
fix wayland stuck on resgitering wl_output

### DIFF
--- a/src/native-state-wayland.cpp
+++ b/src/native-state-wayland.cpp
@@ -109,7 +109,6 @@ NativeStateWayland::registry_handle_global(void *data, struct wl_registry *regis
         that->display_->outputs.push_back(my_output);
 
         wl_output_add_listener(my_output->output, &output_listener_, my_output);
-        wl_display_roundtrip(that->display_->display);
     }
 }
 


### PR DESCRIPTION
Issue was found on Freescale i.MX6 boards with a customized weston compositor.
Program stuck on wl_display_roundtrip when registering wl_output, and was not responding to SIGTERM and SIGINT.
I have to do a "kill -9" to stop that.