### PR TITLE
drm: Add sun4i-drm driver in the list of DRM Modules

### DIFF
--- a/src/native-state-drm.cpp
+++ b/src/native-state-drm.cpp
@@ -362,6 +362,7 @@ static int open_using_module_checking()
         "pl111",
         "vc4",
         "meson",
+        "sun4i-drm",
     };
 
     int fd = -1;


### PR DESCRIPTION
Tested with NanoPi M1 using the Lima Driver

Signed-off-by: Sahaj Sarup <sahaj.sarup@linaro.org>