### PR TITLE
drm: fixes in error handling

### DIFF
--- a/src/native-state-drm.cpp
+++ b/src/native-state-drm.cpp
@@ -330,7 +330,7 @@ static int open_using_udev_scan()
 
     if (!valid_fd(fd)) {
         // %m is GLIBC specific... Maybe use strerror here...
-        Log::error("Tried to use '%s' but failed.\nReason : %m",
+        Log::error("Tried to use '%s' but failed.\nReason : %m\n",
                    dev_path.c_str());
     }
     else

--- a/src/native-state-drm.h
+++ b/src/native-state-drm.h
@@ -41,6 +41,7 @@ public:
         resources_(0),
         connector_(0),
         encoder_(0),
+        crtc_(0),
         mode_(0),
         dev_(0),
         surface_(0),


### PR DESCRIPTION
This fixes two issues in error hanlding. Especially the second commit prevents glmark2 from crashing in case it could not initialize DRM properly.