### PR TITLE
drm: add "msm" to list of drm modules

### DIFF
--- a/src/native-state-drm.cpp
+++ b/src/native-state-drm.cpp
@@ -361,6 +361,7 @@ static int open_using_module_checking()
         "exynos",
         "pl111",
         "vc4",
+        "msm",
         "meson",
         "sun4i-drm",
     };


### PR DESCRIPTION
So that freedreno works.