### PR TITLE
drm: add rockchip to module list

### DIFF
--- a/src/native-state-drm.cpp
+++ b/src/native-state-drm.cpp
@@ -363,6 +363,7 @@ static int open_using_module_checking()
         "vc4",
         "msm",
         "meson",
+        "rockchip",
         "sun4i-drm",
         "stm",
     };


### PR DESCRIPTION
This allows glmark to also work when the legacy init is used.

Signed-off-by: Heiko Stuebner <heiko@sntech.de>