### PR TITLE
drm: check for resources presence on udev-selected drm devices

### DIFF
--- a/src/native-state-drm.cpp
+++ b/src/native-state-drm.cpp
@@ -212,6 +212,25 @@ udev_drm_test_primary_gpu(UDEV_TEST_FUNC_SIGNATURE(, current_device,))
     return is_main_gpu;
 }
 
+/* Test if the drm-device is actually modeset capable.
+ * Render-only devices cannot drive an actual display,
+ * so the GETRESOURCES ioctl will fail in that case.
+ */
+static bool udev_drm_test_modeset(std::string dev_path)
+{
+    struct drm_mode_card_res res {};
+    int fd, ret;
+
+    fd = open(dev_path.c_str(), O_RDWR);
+    if (!valid_fd(fd))
+        return false;
+
+    ret = drmIoctl(fd, DRM_IOCTL_MODE_GETRESOURCES, &res);
+    drmClose(fd);
+
+    return !ret;
+}
+
 static std::string
 udev_get_node_that_pass_in_enum(
     struct udev * __restrict const udev,
@@ -236,8 +255,9 @@ udev_get_node_that_pass_in_enum(
             if (check_passed) {
                 const char * device_node_path =
                     udev_device_get_devnode(current_device);
+                bool is_modeset = udev_drm_test_modeset(device_node_path);
 
-                if (device_node_path) {
+                if (device_node_path && is_modeset) {
                     result = device_node_path;
                 }
 


### PR DESCRIPTION
render-only drm-devices cannot drive actual displays but are valid
when iterating through the udev device list. Instead they simply
share buffers with actual output drm devices via prime.

To separate these two types try opening the device and do a throw-
away GET_RESOURCES ioctl to check for actual output capability if
if a render-only device got selected first.
