### PR TITLE
Fix Windows 32-bit build.

### DIFF
--- a/src/gl-headers.cpp
+++ b/src/gl-headers.cpp
@@ -21,8 +21,8 @@
  */
 #include "gl-headers.h"
 
-void* (*GLExtensions::MapBuffer) (GLenum target, GLenum access) = 0;
-GLboolean (*GLExtensions::UnmapBuffer) (GLenum target) = 0;
+void* (GLAD_API_PTR *GLExtensions::MapBuffer) (GLenum target, GLenum access) = 0;
+GLboolean (GLAD_API_PTR *GLExtensions::UnmapBuffer) (GLenum target) = 0;
 
 bool
 GLExtensions::support(const std::string &ext)

--- a/src/gl-headers.h
+++ b/src/gl-headers.h
@@ -62,8 +62,8 @@ struct GLExtensions {
      */
     static bool support(const std::string &ext);
 
-    static void* (*MapBuffer) (GLenum target, GLenum access);
-    static GLboolean (*UnmapBuffer) (GLenum target);
+    static void* (GLAD_API_PTR *MapBuffer) (GLenum target, GLenum access);
+    static GLboolean (GLAD_API_PTR *UnmapBuffer) (GLenum target);
 };
 
 #endif


### PR DESCRIPTION
Function pointers require that __stdcall be used in the prototype.
This was missing on the extension pointers used in gl-headers.h.

@afrantzis PTAL. One follow-up issues noticed when trying to integrate with our bots.