### PR TITLE
Android updates

### DIFF
--- a/INSTALL.android
+++ b/INSTALL.android
@@ -1,7 +1,25 @@
-The minimum Android API level for glmark2 is 9 (>= Android 2.3).
+A build script for Linux has been added which simplifies the process of
+creating an APK.
+
+Any recent toolchain (released in 2018 or later) should work.  The steps
+using build-tools have been hard coded to 26.0.1, but could be made
+configurable, or update the script to point to installed version.
+
+Tested with NDK r18b.
+
+$ sudo apt-get install openjdk-8-jdk
+$ export ANDROID_SDK=/path/to/Android/Sdk
+$ export ANDROID_NDK=/path/to/Android/Sdk/ndk-bundle
+$ export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+$ cd android
+$ ./build.sh
+$ adb install glmark2.apk
 
 Building using the SDK and NDK
 ------------------------------
+
+Note: These build steps require older SDK and NDK.  Later revisions have
+removed the android and ant scripts.
 
 To build and install glmark2 you need the Android SDK and NDK. The 'android',
 'adb' and 'ndk-build' tools used below are included there.

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -50,5 +50,6 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-feature android:glEsVersion="0x00020000"/>
-    <uses-sdk android:minSdkVersion="9"/>
+    <uses-sdk android:minSdkVersion="16"/>
+    <uses-sdk android:targetSdkVersion="23"/>
 </manifest>

--- a/android/build.sh
+++ b/android/build.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Copyright 2019 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ -z "${ANDROID_SDK}" ];
+then echo "Please set ANDROID_SDK, exiting"; exit 1;
+else echo "ANDROID_SDK is ${ANDROID_SDK}";
+fi
+
+if [ -z "${ANDROID_NDK}" ];
+then echo "Please set ANDROID_NDK, exiting"; exit 1;
+else echo "ANDROID_NDK is ${ANDROID_NDK}";
+fi
+
+if [ -z "${JAVA_HOME}" ];
+then echo "Please set JAVA_HOME, exiting"; exit 1;
+else echo "JAVA_HOME is ${JAVA_HOME}";
+fi
+
+BUILD_TOOLS_VERSION=26.0.1
+BUILD_TOOLS=$ANDROID_SDK/build-tools/$BUILD_TOOLS_VERSION
+if [ ! -d "${BUILD_TOOLS}" ];
+then echo "Please download correct build-tools version: ${BUILD_TOOLS_VERSION}, exiting"; exit 1;
+else echo "BUILD_TOOLS is ${BUILD_TOOLS}";
+fi
+
+set -ev
+
+GLMARK2_BUILD_DIR=$PWD
+GLMARK2_BASE_DIR=$GLMARK2_BUILD_DIR/..
+echo GLMARK2_BASE_DIR="${GLMARK2_BASE_DIR}"
+echo GLMARK2_BUILD_DIR="${GLMARK2_BUILD_DIR}"
+
+# Android 16 is the minSdkVersion supported
+ANDROID_JAR=$ANDROID_SDK/platforms/android-16/android.jar
+
+function create_APK() {
+    mkdir -p bin/lib obj
+    cp -r $GLMARK2_BUILD_DIR/libs/* $GLMARK2_BUILD_DIR/bin/lib
+    cp -r $GLMARK2_BASE_DIR/data $GLMARK2_BUILD_DIR/bin/assets
+    $BUILD_TOOLS/aapt package -f -m -S res -J src -M AndroidManifest.xml -I $ANDROID_JAR
+    $JAVA_HOME/bin/javac -d ./obj -source 1.7 -target 1.7 -bootclasspath $JAVA_HOME/jre/lib/rt.jar -classpath $ANDROID_JAR:obj -sourcepath src src/org/linaro/glmark2/*.java
+    $BUILD_TOOLS/dx --dex --output=bin/classes.dex ./obj
+    $BUILD_TOOLS/aapt package -f -M AndroidManifest.xml -S res -I $ANDROID_JAR -F $1-unaligned.apk bin
+    $JAVA_HOME/bin/jarsigner -verbose -keystore ~/.android/debug.keystore -storepass android -keypass android  $1-unaligned.apk androiddebugkey
+    $BUILD_TOOLS/zipalign -f 4 $1-unaligned.apk $1.apk
+}
+
+#
+# build native libraries
+#
+$ANDROID_NDK/build/ndk-build -j $cores
+
+#
+# build glmark2 APK
+#
+create_APK glmark2
+
+echo Builds succeeded
+exit 0

--- a/android/jni/Android.ndk.mk
+++ b/android/jni/Android.ndk.mk
@@ -24,10 +24,51 @@ LOCAL_MODULE := libglmark2-jpeg
 LOCAL_CFLAGS := -Werror -Wall -Wextra -Wno-error=attributes \
                 -Wno-error=unused-parameter -Wno-error=unused-function -Wno-error=unused-variable
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/src/libjpeg-turbo/
-LOCAL_SRC_FILES := $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/simd/*.c)) \
-                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/simd/*.S)) \
-                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/*.c))
-
+LOCAL_SRC_FILES := $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jcapimin.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jcapistd.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jccoefct.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jccolor.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jcdctmgr.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jchuff.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jcinit.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jcmainct.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jcmarker.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jcmaster.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jcomapi.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jcparam.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jcphuff.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jcprepct.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jcsample.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jdapimin.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jdapistd.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jdatadst.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jdatasrc.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jdcoefct.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jdcolor.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jddctmgr.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jdhuff.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jdinput.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jdmainct.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jdmarker.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jdmaster.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jdmerge.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jdphuff.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jdpostct.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jdsample.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jerror.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jfdctflt.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jfdctfst.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jfdctint.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jidctflt.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jidctfst.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jidctint.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jidctred.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jmemmgr.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jmemnobs.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jquant1.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jquant2.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jutils.c)) \
+                   $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libjpeg-turbo/jsimd_none.c))
 include $(BUILD_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)

--- a/android/jni/Android.ndk.mk
+++ b/android/jni/Android.ndk.mk
@@ -6,7 +6,8 @@ LOCAL_CPP_EXTENSION := .cc
 LOCAL_MODULE := libglmark2-matrix
 LOCAL_CFLAGS := -DGLMARK2_USE_GLESv2 -Werror -Wall -Wextra -Wnon-virtual-dtor \
                 -Wno-error=unused-parameter
-LOCAL_C_INCLUDES := $(LOCAL_PATH)/src
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/src \
+                    $(LOCAL_PATH)/src/glad/include
 LOCAL_SRC_FILES := $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/libmatrix/*.cc))
 
 include $(BUILD_STATIC_LIBRARY)
@@ -78,26 +79,40 @@ LOCAL_MODULE := libglmark2-ideas
 LOCAL_CFLAGS := -DGLMARK_DATA_PATH="" -DGLMARK2_USE_GLESv2 -Werror -Wall -Wextra\
                 -Wnon-virtual-dtor -Wno-error=unused-parameter
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/src \
-                    $(LOCAL_PATH)/src/libmatrix
+                    $(LOCAL_PATH)/src/libmatrix \
+                    $(LOCAL_PATH)/src/glad/include
 LOCAL_SRC_FILES := $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/scene-ideas/*.cc))
-
 include $(BUILD_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
+LOCAL_MODULE := libglad-egl
+LOCAL_CFLAGS := -Werror -Wall
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/src/glad/include
+LOCAL_SRC_FILES := $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/glad/src/egl.c))
+include $(BUILD_STATIC_LIBRARY)
 
+include $(CLEAR_VARS)
+LOCAL_MODULE := libglad-glesv2
+LOCAL_CFLAGS := -Werror -Wall
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/src/glad/include
+LOCAL_SRC_FILES := $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/glad/src/gles2.c))
+include $(BUILD_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := libglmark2-android
-LOCAL_STATIC_LIBRARIES := libglmark2-matrix libglmark2-png libglmark2-ideas libglmark2-jpeg
+LOCAL_STATIC_LIBRARIES := libglmark2-matrix libglmark2-png libglmark2-ideas libglmark2-jpeg libglad-egl libglad-glesv2
 LOCAL_CFLAGS := -DGLMARK_DATA_PATH="" -DGLMARK_VERSION="\"2017.07\"" \
                 -DGLMARK2_USE_GLESv2 -Werror -Wall -Wextra -Wnon-virtual-dtor \
                 -Wno-error=unused-parameter
-LOCAL_LDLIBS := -landroid -llog -lGLESv2 -lEGL -lz
+LOCAL_LDLIBS := -landroid -llog -lz
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/src \
                     $(LOCAL_PATH)/src/libmatrix \
                     $(LOCAL_PATH)/src/scene-ideas \
                     $(LOCAL_PATH)/src/scene-terrain \
                     $(LOCAL_PATH)/src/libjpeg-turbo \
-                    $(LOCAL_PATH)/src/libpng
+                    $(LOCAL_PATH)/src/libpng \
+                    $(LOCAL_PATH)/src/glad/include
 LOCAL_SRC_FILES := $(filter-out src/canvas% src/gl-state% src/native-state% src/main.cpp, \
                      $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/*.cpp))) \
                    $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/src/scene-terrain/*.cpp)) \

--- a/android/jni/Application.mk
+++ b/android/jni/Application.mk
@@ -1,3 +1,4 @@
-APP_STL := stlport_static
-APP_PLATFORM := android-9
+APP_ABI := all
+APP_STL := c++_static
+APP_PLATFORM := android-16
 APP_BUILD_SCRIPT := jni/Android.ndk.mk

--- a/src/canvas-android.cpp
+++ b/src/canvas-android.cpp
@@ -24,7 +24,7 @@
 #include "log.h"
 #include "options.h"
 #include "gl-headers.h"
-#include <EGL/egl.h>
+#include "glad/egl.h"
 
 #include <fstream>
 #include <sstream>

--- a/src/canvas-android.h
+++ b/src/canvas-android.h
@@ -23,6 +23,8 @@
 #define GLMARK2_CANVAS_ANDROID_H_
 
 #include "canvas.h"
+#include "shared-library.h"
+#include "glad/egl.h"
 
 /**
  * Canvas for rendering to Android surfaces.
@@ -49,6 +51,10 @@ public:
     void resize(int width, int height);
 
 private:
+    SharedLibrary egl_lib_;
+    SharedLibrary gles_lib_;
+
+    static GLADapiproc load_proc(const char *name, void *userdata);
     void init_gl_extensions();
 };
 


### PR DESCRIPTION
These are the Android updates from https://github.com/glmark2/glmark2/pull/78

I think the main concern previously was requiring more recent Android versions, and this PR keeps API 9 as in the min.

We've been using glmark2 quite a bit to drive ANGLE progress, so it would be great to pull from upstream instead of my downstream branch.