### PR TITLE
Set swap interval to 0 for WGL when possible.

### DIFF
--- a/src/gl-state-wgl.cpp
+++ b/src/gl-state-wgl.cpp
@@ -21,6 +21,7 @@
 //
 #include "gl-state-wgl.h"
 
+#include <glad/wgl.h>
 #include "gl-headers.h"
 #include "log.h"
 #include "options.h"
@@ -90,6 +91,11 @@ GLStateWGL::init_display(void* native_display, GLVisualConfig& /*visual_config*/
     }
 
     if (gladLoadGLUserPtr(load_proc, this) == 0) {
+        Log::error("Failed to load GL entry points\n");
+        return false;
+    }
+
+    if (gladLoadWGLUserPtr(hdc_, load_proc, this) == 0) {
         Log::error("Failed to load WGL entry points\n");
         return false;
     }
@@ -114,6 +120,10 @@ GLStateWGL::init_gl_extensions()
 bool
 GLStateWGL::valid()
 {
+    if (!wglSwapIntervalEXT || wglSwapIntervalEXT(0) == FALSE) {
+        Log::info("** Failed to set swap interval. Results may be bounded above by refresh rate.\n");
+    }
+
     return wgl_context_ != nullptr;
 }
 

--- a/src/wscript_build
+++ b/src/wscript_build
@@ -70,7 +70,7 @@ flavor_uselibs = {
   'mir-glesv2' : ['mirclient', 'glad-egl-mir', 'glad-glesv2', 'matrix-glesv2', 'common-glesv2'],
   'wayland-gl' : ['wayland-client', 'wayland-egl', 'glad-egl-wayland', 'glad-gl', 'matrix-gl', 'common-gl'],
   'wayland-glesv2' : ['wayland-client', 'wayland-egl', 'glad-egl-wayland', 'glad-glesv2', 'matrix-glesv2', 'common-glesv2'],
-  'win32-gl': ['glad-gl', 'matrix-gl', 'common-gl'],
+  'win32-gl': ['glad-gl', 'glad-wgl', 'matrix-gl', 'common-gl'],
   'win32-glesv2': ['glad-egl-win32', 'glad-glesv2', 'matrix-glesv2', 'common-glesv2'],
   'x11-gl' : ['x11', 'glad-gl', 'glad-glx', 'matrix-gl', 'common-gl'],
   'x11-glesv2' : ['x11', 'glad-egl-x11', 'glad-glesv2', 'matrix-glesv2', 'common-glesv2'],
@@ -162,6 +162,15 @@ if 'glad-gl' in all_uselibs:
         export_includes = 'glad/include'
         )
 
+if 'glad-wgl' in all_uselibs:
+    bld(
+        features = ['c'],
+        source   = ['glad/src/wgl.c'],
+        target   = 'glad-wgl',
+        includes = ['glad/include'],
+        export_includes = 'glad/include'
+        )
+
 if 'glad-glesv2' in all_uselibs:
     bld(
         features = ['c'],
@@ -200,7 +209,7 @@ if 'libpng-local' in all_uselibs:
         features  = ['c'],
         source    = libpng_local_sources,
         target    = 'libpng-local',
-        use       = ['zlib'],
+        use       = ['zlib-local'],
         export_includes = 'libpng'
         )
 


### PR DESCRIPTION
This should give better benchmark results as they won't be bounded
by the screen's refresh rate. Note that this relies on a WGL
extension.

Also fixes a Windows WGL build regression introduced in #94.

Fixes #90

@afrantzis PTAL. Not extensively tested but seems to work on my machine.