### PR TITLE
glad: Fix EGL loading for EGL_NO_DISPLAY on EGL 1.5 and above

### DIFF
--- a/src/glad/src/egl.c
+++ b/src/glad/src/egl.c
@@ -202,9 +202,11 @@ static int glad_egl_find_core_egl(EGLDisplay display) {
         display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
     }
 #endif
+#ifndef EGL_VERSION_1_5
     if (display == EGL_NO_DISPLAY) {
         return 0;
     }
+#endif
 
     version = eglQueryString(display, EGL_VERSION);
     (void) eglGetError();


### PR DESCRIPTION
EGL loading was failing for a display of EGL_NO_DISPLAY.
Allow loading EGL 1.5 and above since eglQueryString supports
EGL_NO_DISPLAY in this case.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>