### PR TITLE
Port Wayland to xdg-shell

### DIFF
--- a/src/native-state-wayland.h
+++ b/src/native-state-wayland.h
@@ -91,6 +91,7 @@ private:
         wl_output *output;
         int32_t width, height;
         int32_t refresh;
+        int32_t scale;
     };
 
     typedef std::vector<struct my_output *> OutputsVector;

--- a/src/native-state-wayland.h
+++ b/src/native-state-wayland.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include <wayland-client.h>
 #include <wayland-egl.h>
+#include "xdg-shell-client-protocol.h"
 
 #include "native-state.h"
 
@@ -47,7 +48,9 @@ private:
     static void quit_handler(int signum);
 
     static const struct wl_registry_listener registry_listener_;
-    static const struct wl_shell_surface_listener shell_surface_listener_;
+    static const struct xdg_wm_base_listener xdg_wm_base_listener_;
+    static const struct xdg_surface_listener xdg_surface_listener_;
+    static const struct xdg_toplevel_listener xdg_toplevel_listener_;
     static const struct wl_output_listener output_listener_;
 
     static void
@@ -76,16 +79,18 @@ private:
     output_handle_scale(void *data, struct wl_output *wl_output, int32_t factor);
 
     static void
-    shell_surface_handle_ping(void *data, struct wl_shell_surface *shell_surface,
-                              uint32_t serial);
+    xdg_wm_base_handle_ping(void *data, struct xdg_wm_base *xdg_wm_base,
+                            uint32_t serial);
     static void
-    shell_surface_handle_configure(void *data,
-                                   struct wl_shell_surface *shell_surface,
-                                   uint32_t edges,
-                                   int32_t width, int32_t height);
+    xdg_toplevel_handle_configure(void *data,
+                                  struct xdg_toplevel *xdg_toplevel,
+                                  int32_t width, int32_t height,
+                                  struct wl_array *states);
     static void
-    shell_surface_handle_popup_done(void *data,
-                                    struct wl_shell_surface *shell_surface);
+    xdg_toplevel_handle_close(void *data, struct xdg_toplevel *xdg_toplevel);
+    static void
+    xdg_surface_handle_configure(void *data, struct xdg_surface *xdg_surface,
+                                 uint32_t serial);
 
     struct my_output {
         wl_output *output;
@@ -100,15 +105,17 @@ private:
         wl_display *display;
         wl_registry *registry;
         wl_compositor *compositor;
-        wl_shell *shell;
+        struct xdg_wm_base *xdg_wm_base;
         OutputsVector outputs;
     } *display_;
 
     struct my_window {
         WindowProperties properties;
+        bool waiting_for_configure;
         struct wl_surface *surface;
         struct wl_egl_window *native;
-        struct wl_shell_surface *shell_surface;
+        struct xdg_surface *xdg_surface;
+        struct xdg_toplevel *xdg_toplevel;
     } *window_;
 
     static volatile bool should_quit_;

--- a/src/wscript_build
+++ b/src/wscript_build
@@ -102,6 +102,32 @@ flavor_libs = {
   'x11-gl' : [],
   'x11-glesv2' : [],
 }
+flavor_depends_on = {
+  'dispmanx-glesv2' : [],
+  'drm-gl' : [],
+  'drm-glesv2' : [],
+  'mir-gl' : [],
+  'mir-glesv2' : [],
+  'wayland-gl' : [],
+  'wayland-glesv2' : [],
+  'win32-gl': [],
+  'win32-glesv2' : [],
+  'x11-gl' : [],
+  'x11-glesv2' : [],
+}
+flavor_sources_gen = {
+  'dispmanx-glesv2' : [],
+  'drm-gl' : [],
+  'drm-glesv2' : [],
+  'mir-gl' : [],
+  'mir-glesv2' : [],
+  'wayland-gl' : [],
+  'wayland-glesv2' : [],
+  'win32-gl': [],
+  'win32-glesv2' : [],
+  'x11-gl' : [],
+  'x11-glesv2' : [],
+}
 egl_platform_defines = {
   'dispmanx' : ['MESA_EGL_NO_X11_HEADERS'],
   'drm' : ['__GBM__'],
@@ -120,7 +146,7 @@ for name in bld.env.keys():
         flavor = name.replace('FLAVOR_', '').lower().replace('_', '-')
         egl_platform = flavor.split('-')[0]
         target = bld.env[name]
-        bld(
+        node = bld(
             features     = ['cxx', 'cprogram'],
             source       = flavor_sources[flavor],
             target       = target,
@@ -128,8 +154,11 @@ for name in bld.env.keys():
             lib          = platform_libs + flavor_libs[flavor],
             includes     = ['.'] + platform_includes,
             defines      = common_defines + flavor_defines[flavor] +
-                           egl_platform_defines[egl_platform]
+                           egl_platform_defines[egl_platform],
+            depends_on   = flavor_depends_on[flavor]
             )
+        if flavor_sources_gen[flavor]:
+            node.source.extend(flavor_sources_gen[flavor])
         all_uselibs |= set(flavor_uselibs[flavor] + platform_uselibs)
 
 # Build glad-egl for all used EGL platforms

--- a/src/wscript_build
+++ b/src/wscript_build
@@ -49,6 +49,35 @@ else:
   platform_uselibs += ['libpng']
   platform_libs = ['m', 'jpeg', 'dl']
 
+if 'WAYLAND_SCANNER_wayland_scanner' in bld.env.keys():
+    def wayland_scanner_cmd(arg, src):
+        return '%s %s < %s > ${TGT}' % (bld.env['WAYLAND_SCANNER_wayland_scanner'], arg, src)
+
+    def wayland_proto_src_path(proto, ver):
+        wp_dir = bld.env['WAYLAND_PROTOCOLS_pkgdatadir']
+        if ver == 'stable':
+            return '%s/stable/%s/%s.xml' % (wp_dir, proto, proto)
+        else:
+            return '%s/unstable/%s/%s-unstable-%s.xml' % (wp_dir, proto, proto, ver)
+
+    def wayland_client_protocol(proto, ver, dst_base):
+        src_path = wayland_proto_src_path(proto, ver)
+        out = '%s-client-protocol.h' % dst_base
+        return bld(rule = wayland_scanner_cmd('client-header', src_path),
+                   target = out,
+                   name = out,
+                   ext_out = ['.h'])
+
+    def wayland_protocol_code(proto, ver, dst_base):
+        src_path = wayland_proto_src_path(proto, ver)
+        out = '%s-protocol.c' % dst_base
+        return bld(rule = wayland_scanner_cmd('private-code', src_path),
+                   target = out,
+                   name = out)
+
+    wayland_client_protocol('xdg-shell', 'stable', 'xdg-shell')
+    wayland_protocol_code('xdg-shell', 'stable', 'xdg-shell')
+
 flavor_sources = {
   'dispmanx-glesv2' : common_flavor_sources + ['native-state-dispmanx.cpp', 'gl-state-egl.cpp'],
   'drm-gl' : common_flavor_sources + ['native-state-drm.cpp', 'gl-state-egl.cpp'],
@@ -108,8 +137,8 @@ flavor_depends_on = {
   'drm-glesv2' : [],
   'mir-gl' : [],
   'mir-glesv2' : [],
-  'wayland-gl' : [],
-  'wayland-glesv2' : [],
+  'wayland-gl' : ['xdg-shell-client-protocol.h', 'xdg-shell-protocol.c'],
+  'wayland-glesv2' : ['xdg-shell-client-protocol.h', 'xdg-shell-protocol.c'],
   'win32-gl': [],
   'win32-glesv2' : [],
   'x11-gl' : [],
@@ -121,8 +150,8 @@ flavor_sources_gen = {
   'drm-glesv2' : [],
   'mir-gl' : [],
   'mir-glesv2' : [],
-  'wayland-gl' : [],
-  'wayland-glesv2' : [],
+  'wayland-gl' : [bld.path.find_or_declare('xdg-shell-protocol.c')],
+  'wayland-glesv2' : [bld.path.find_or_declare('xdg-shell-protocol.c')],
   'win32-gl': [],
   'win32-glesv2' : [],
   'x11-gl' : [],

--- a/wscript
+++ b/wscript
@@ -219,6 +219,13 @@ def configure_linux(ctx):
             ctx.check_cfg(package = pkg, uselib_store = uselib, atleast_version=atleast,
                           args = '--cflags --libs', mandatory = mandatory)
 
+    if list_contains(ctx.options.flavors, 'wayland'):
+        # wayland-protocols >= 1.12 required for xdg-shell stable
+        ctx.check_cfg(package = 'wayland-protocols', atleast_version = '1.12',
+                      variables = ['pkgdatadir'], uselib_store = 'WAYLAND_PROTOCOLS')
+        ctx.check_cfg(package = 'wayland-scanner', variables = ['wayland_scanner'],
+                      uselib_store = 'WAYLAND_SCANNER')
+
     # Prepend CXX flags so that they can be overriden by the
     # CXXFLAGS environment variable
     if ctx.options.opt:


### PR DESCRIPTION
The wl_shell protocol used by glmark2 for its Wayland window management has been deprecated for quite some years. It is not supported by all environments, and also has notably broken fullscreen and HiDPI behaviour.

Replace wl_shell with xdg-shell, which is implemented by everyone and also actually works.