### PR TITLE
Check for proper initialization of native_window and MVC matrix

### DIFF
--- a/src/canvas-generic.cpp
+++ b/src/canvas-generic.cpp
@@ -249,6 +249,7 @@ CanvasGeneric::resize_no_viewport(int width, int height)
     }
 
     native_window_ = native_state_.window(cur_properties);
+    window_initialized_ = true;
 
     width_ = cur_properties.width;
     height_ = cur_properties.height;
@@ -274,6 +275,12 @@ CanvasGeneric::resize_no_viewport(int width, int height)
 bool
 CanvasGeneric::do_make_current()
 {
+    if(!window_initialized_)
+    {
+        Log::error("glwindow has never been initialized, check native-state code\n"
+                   "it should not return a valid window until create_window() is called\n");
+        return false;
+    }
     gl_state_.init_surface(native_window_);
 
     if (!gl_state_.valid()) {

--- a/src/canvas-generic.h
+++ b/src/canvas-generic.h
@@ -37,9 +37,10 @@ public:
     CanvasGeneric(NativeState& native_state, GLState& gl_state,
                   int width, int height)
         : Canvas(width, height),
-          native_state_(native_state), gl_state_(gl_state),
+          native_state_(native_state), gl_state_(gl_state),native_window_(0),
           gl_color_format_(0), gl_depth_format_(0),
-          color_renderbuffer_(0), depth_renderbuffer_(0), fbo_(0) {}
+          color_renderbuffer_(0), depth_renderbuffer_(0), fbo_(0),
+          window_initialized_(false) {}
 
     bool init();
     bool reset();
@@ -70,6 +71,7 @@ private:
     GLuint color_renderbuffer_;
     GLuint depth_renderbuffer_;
     GLuint fbo_;
+    bool   window_initialized_;
 };
 
 #endif /* GLMARK2_CANVAS_GENERIC_H_ */


### PR DESCRIPTION
I've added a check for the proper initialization of the native_window pointer and of the projection matrix. I wrote a framebuffer backend for and imx6 embedded device and I found that's very easy to modify the native-state-* in a way that lead to CanvasGeneric::projection_ not being initialized and to a very hard to find bug with half of the benchmarks rendering a black screen since the drawing is off the screen; moreover it's very difficult to track down since matrices are default initialized to the identity and therefore the values loaded in the shaders don't look plain wrong.

The problem is this, suppose we have a native-state without windows, because we don't have anything like a window system, then it'll be natural to write code like this:

```
bool NativeStateFb::create_window(WindowProperties const& )
{
    return true; //nothing to do here,just return true
}
void* NativeStateFb::window(WindowProperties& properties)
{
    properties.width = width;
    properties.height = height;
    properties.fullscreen = true;
    properties.visual_id = 0;
    return theNativeWindow;
}

```

now canvan-generic will call window() to check if the size is correct

```
bool
CanvasGeneric::resize_no_viewport(int width, int height)
{
    bool request_fullscreen = (width == -1 && height == -1);

    intptr_t vid;
    if (!gl_state_.gotNativeConfig(vid))
    {
        Log::error("Error: Couldn't get GL visual config!\n");
        return false;
    }

    NativeState::WindowProperties properties(width, height,
                                             request_fullscreen, vid);
    NativeState::WindowProperties cur_properties;

    native_state_.window(cur_properties);

    if ((cur_properties.fullscreen == properties.fullscreen &&
         cur_properties.width > 0 && cur_properties.height > 0) ||
        (cur_properties.width == properties.width &&
         cur_properties.height == properties.height))
    {
        return true;
    }

```

if the size is actually the same in properties ( because you happen to have a device which is 800x600, like the defaults) you're going to bailout and skip the initialization of the variable `projection` and `native_window_`.

I'm making a pull request because finding this out took me a full day, in the hope to save someone else the effort. 

Regards
Federico

By the way.. this software is able to heat-up imx6 processors like no other.  :+1: 