### PR TITLE
Use Python3 in waf

### DIFF
--- a/waf
+++ b/waf
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: ISO8859-1
+#!/usr/bin/env python3
 # Thomas Nagy, 2005-2016
 #
 """


### PR DESCRIPTION
Works for me (Linux, Debian testing).

I don't have Python 2 installed anymore.

Remove encoding. UTF-8 is standard in Python 3.