### PR TITLE
wscript: use find_program to find wayland-scanner

### DIFF
--- a/src/wscript_build
+++ b/src/wscript_build
@@ -51,7 +51,7 @@ else:
 
 if 'WAYLAND_SCANNER_wayland_scanner' in bld.env.keys():
     def wayland_scanner_cmd(arg, src):
-        return '%s %s < %s > ${TGT}' % (bld.env['WAYLAND_SCANNER_wayland_scanner'], arg, src)
+        return '%s %s < %s > ${TGT}' % (bld.env['WAYLAND_SCANNER_wayland_scanner'][0], arg, src)
 
     def wayland_proto_src_path(proto, ver):
         wp_dir = bld.env['WAYLAND_PROTOCOLS_pkgdatadir']

--- a/wscript
+++ b/wscript
@@ -227,8 +227,7 @@ def configure_linux(ctx):
         # wayland-protocols >= 1.12 required for xdg-shell stable
         ctx.check_cfg(package = 'wayland-protocols', atleast_version = '1.12',
                       variables = ['pkgdatadir'], uselib_store = 'WAYLAND_PROTOCOLS')
-        ctx.check_cfg(package = 'wayland-scanner', variables = ['wayland_scanner'],
-                      uselib_store = 'WAYLAND_SCANNER')
+        ctx.find_program('wayland-scanner', var = 'WAYLAND_SCANNER_wayland_scanner')
 
     # Prepend CXX flags so that they can be overriden by the
     # CXXFLAGS environment variable


### PR DESCRIPTION
Use find_program instead of check_cfg to find wayland-scanner. This will
fix the following build failure when cross-compiling:

[ 3/73] Compiling doc/glmark2.1.in
/bin/sh: 1: /usr/bin/wayland-scanner: not found

Fixes:
 - http://autobuild.buildroot.org/results//361dc40e558e2646cb93f405c7b1f621d400fea3

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>