### PR TITLE
Fix precision handling bugs resulting in corrupted rendering on some drivers

### DIFF
--- a/data/shaders/conditionals.frag
+++ b/data/shaders/conditionals.frag
@@ -2,7 +2,14 @@ varying vec4 dummy;
 
 void main(void)
 {
-    float d = fract(gl_FragCoord.x * gl_FragCoord.y * 0.0001);
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+    // should be declared highp since the multiplication can overflow in
+    // mediump, particularly if mediump is implemented as fp16
+    highp vec2 FragCoord = gl_FragCoord.xy;
+#else
+    vec2 FragCoord = gl_FragCoord.xy;
+#endif
+    float d = fract(FragCoord.x * FragCoord.y * 0.0001);
 
 $MAIN$
 

--- a/data/shaders/function.frag
+++ b/data/shaders/function.frag
@@ -8,7 +8,14 @@ $PROCESS$
 
 void main(void)
 {
-    float d = fract(gl_FragCoord.x * gl_FragCoord.y * 0.0001);
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+    // should be declared highp since the multiplication can overflow in
+    // mediump, particularly if mediump is implemented as fp16
+    highp vec2 FragCoord = gl_FragCoord.xy;
+#else
+    vec2 FragCoord = gl_FragCoord.xy;
+#endif
+    float d = fract(FragCoord.x * FragCoord.y * 0.0001);
 
 $MAIN$
 

--- a/data/shaders/loop.frag
+++ b/data/shaders/loop.frag
@@ -3,7 +3,14 @@ uniform int FragmentLoops;
 
 void main(void)
 {
-    float d = fract(gl_FragCoord.x * gl_FragCoord.y * 0.0001);
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+    // should be declared highp since the multiplication can overflow in
+    // mediump, particularly if mediump is implemented as fp16
+    highp vec2 FragCoord = gl_FragCoord.xy;
+#else
+    vec2 FragCoord = gl_FragCoord.xy;
+#endif
+    float d = fract(FragCoord.x * FragCoord.y * 0.0001);
 
 $MAIN$
 

--- a/data/shaders/terrain-noise.frag
+++ b/data/shaders/terrain-noise.frag
@@ -17,7 +17,13 @@ uniform float time;
 uniform MEDIUMP vec2 uvScale;
 varying vec2 vUv;
 
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+// x should be passed as highp since the intermediate multiplications can
+// overflow with mediump
+vec4 permute(highp vec4 x)
+#else
 vec4 permute(vec4 x)
+#endif
 {
     return mod(((x * 34.0) + 1.0) * x, 289.0);
 }

--- a/data/shaders/terrain.frag
+++ b/data/shaders/terrain.frag
@@ -67,7 +67,12 @@ void main() {
     vec3 pointSpecular = vec3( 0.0 );
     for ( int i = 0; i < MAX_POINT_LIGHTS; i ++ ) {
         vec4 lPosition = viewMatrix * vec4( pointLightPosition[ i ], 1.0 );
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+        // should be highp for correct behaviour if mediump is implemented as fp16
+        highp vec3 lVector = lPosition.xyz + vViewPosition.xyz;
+#else
         vec3 lVector = lPosition.xyz + vViewPosition.xyz;
+#endif
         float lDistance = 1.0;
         if ( pointLightDistance[ i ] > 0.0 )
             lDistance = 1.0 - min( ( length( lVector ) / pointLightDistance[ i ] ), 1.0 );


### PR DESCRIPTION
A few shaders can overflow fp16 even though they are correct for fp32, and since this is declared as mediump, the driver may optimize to fp16. So let's declare explicitly as highp where necessary to ensure rendering is correct.

Note these bugs can be masked by drivers that:

* Use full fp32 for mediump
* Clamp to infinity to MAX_FLOAT

Neither behaviour is, to my knowledge, spec required or spec forbidden. So glmark should be patched to conform to the spec's minimum requirements (fp16 with proper Infinity handling) in order to be portable.

---

Cascade of bugs triggered by disabling infinity clamping in Panfrost, fixing upstream makes more sense than trying to workaround glmark bugs.