### PR TITLE
bump: Fix precision bug in height rendering

### DIFF
--- a/data/shaders/bump-height.frag
+++ b/data/shaders/bump-height.frag
@@ -4,7 +4,12 @@ precision mediump float;
 
 uniform sampler2D HeightMap;
 
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+varying highp vec2 TextureCoord;
+#else
 varying vec2 TextureCoord;
+#endif
+
 varying vec3 NormalEye;
 varying vec3 TangentEye;
 varying vec3 BitangentEye;


### PR DESCRIPTION
It's not clear to me why only height mode is affected but this fixes
subtle visual artefacts.

Signed-off-by: Alyssa Rosenzweig <alyssa.rosenzweig@collabora.com>