### PR TITLE
build: glmark2 does not really require libpng version 16

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,7 +25,7 @@ endif
 m_dep = cpp.find_library('m', required : false)
 dl_dep = cpp.find_library('dl')
 libjpeg_dep = dependency('libjpeg')
-libpng_dep = dependency('libpng16')
+libpng_dep = dependency('libpng')
 
 flavors = get_option('flavors')
 if flavors.length() == 0


### PR DESCRIPTION
builds with -Dflavors=x11-gl,x11-glesv2 work fine both on the
systems packaged with libpng12 and libpng15. In addition, meson
seems to deal with this automatically if libpng specified.

Signed-off-by: luc <luc@sietium.com>