### PR TITLE
fix benchmark parameter edition

### DIFF
--- a/android/src/org/linaro/glmark2/EditorActivity.java
+++ b/android/src/org/linaro/glmark2/EditorActivity.java
@@ -173,6 +173,7 @@ public class EditorActivity extends Activity {
                 AlertDialog.Builder builder = new AlertDialog.Builder(this);
                 final EditorItem item = adapter.getItem(itemPos);
                 final EditText input = new EditText(this);
+                input.setSingleLine(true);
                 if (item.value != null)
                     input.setText(item.value);
 


### PR DESCRIPTION
when a parameter of a benchmark is edited and this parameter prompts a
dialog with a EditText, there is no way to validate the new value as the
"Done" button in the virtual keyboard doesn't appear and the "Enter"
button creates a newline in the EditText widget.

this was fixed by forcing the EditText to be single-line.