### PR TITLE
libmatrix: Include missing <utility> header

### DIFF
--- a/src/libmatrix/program.h
+++ b/src/libmatrix/program.h
@@ -13,6 +13,7 @@
 #define PROGRAM_H_
 
 #include <string>
+#include <utility>
 #include <vector>
 #include <map>
 #include <utility>


### PR DESCRIPTION
Fixes build with gcc12
| ../git/src/libmatrix/program.h:43:21: error: 'exchange' is not a member of 'std'                                                   |    43 |         ready_(std::exchange(shader.ready_, false)),                                                                       |       |                     ^~~~~~~~

Signed-off-by: Khem Raj <raj.khem@gmail.com>