### PR TITLE
glmark2: add gbm offscreen backend

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,7 @@ endif
 flavors_str = ', '.join(flavors)
 need_x11 = flavors_str.contains('x11-')
 need_drm = flavors_str.contains('drm-')
+need_gbm = flavors_str.contains('gbm-')
 need_wayland = flavors_str.contains('wayland-')
 need_gl = flavors_str.contains('-gl')
 need_glesv2 = flavors_str.contains('-glesv2')
@@ -50,6 +51,10 @@ if need_drm
     libdrm_dep = dependency('libdrm')
     gbm_dep = dependency('gbm')
     libudev_dep = dependency('libudev')
+endif
+
+if need_gbm
+    gbm_dep = dependency('gbm')
 endif
 
 if need_wayland

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,6 +2,8 @@ option('flavors', type : 'array',
        choices : [
            'drm-gl',
            'drm-glesv2',
+           'gbm-gl',
+           'gbm-glesv2',
            'wayland-gl',
            'wayland-glesv2',
            'x11-gl',

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,8 @@
 #include "native-state-x11.h"
 #elif GLMARK2_USE_DRM
 #include "native-state-drm.h"
+#elif GLMARK2_USE_GBM
+#include "native-state-gbm.h"
 #elif GLMARK2_USE_MIR
 #include "native-state-mir.h"
 #elif GLMARK2_USE_WAYLAND
@@ -174,6 +176,8 @@ main(int argc, char *argv[])
     NativeStateX11 native_state;
 #elif GLMARK2_USE_DRM
     NativeStateDRM native_state;
+#elif GLMARK2_USE_GBM
+    NativeStateGBM native_state;
 #elif GLMARK2_USE_MIR
     NativeStateMir native_state;
 #elif GLMARK2_USE_WAYLAND
@@ -194,7 +198,11 @@ main(int argc, char *argv[])
 
     CanvasGeneric canvas(native_state, gl_state, Options::size.first, Options::size.second);
 
+#if GLMARK2_USE_GBM
+    canvas.offscreen(true);
+#else
     canvas.offscreen(Options::offscreen);
+#endif
 
     canvas.visual_config(Options::visual_config);
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -74,7 +74,7 @@ common_deps = [
     libpng_dep,
     libmatrix_headers_dep,
 ]
-    
+
 if need_drm
     native_drm_lib = static_library(
         'native-drm',
@@ -88,6 +88,21 @@ if need_drm
         )
 else
     native_drm_dep = declare_dependency()
+endif
+
+if need_gbm
+    native_gbm_lib = static_library(
+        'native-gbm',
+        'native-state-gbm.cpp',
+        dependencies: [gbm_dep, gbm_dep, libmatrix_headers_dep],
+        )
+    native_gbm_dep = declare_dependency(
+        link_with: native_gbm_lib,
+        dependencies: gbm_dep,
+        compile_args: ['-DGLMARK2_USE_GBM', '-D__GBM__'],
+        )
+else
+    native_gbm_dep = declare_dependency()
 endif
 
 if need_wayland
@@ -237,6 +252,8 @@ endif
 flavor_info = {
   'drm-gl' : ['glmark2-drm', native_drm_dep, gl_gl_dep, wsi_egl_dep],
   'drm-glesv2' : ['glmark2-es2-drm', native_drm_dep, gl_glesv2_dep, wsi_egl_dep],
+  'gbm-gl' : ['glmark2-gbm', native_gbm_dep, gl_gl_dep, wsi_egl_dep],
+  'gbm-glesv2' : ['glmark2-es2-gbm', native_gbm_dep, gl_glesv2_dep, wsi_egl_dep],
   'wayland-gl' : ['glmark2-wayland', native_wayland_dep, gl_gl_dep, wsi_egl_dep],
   'wayland-glesv2' : ['glmark2-es2-wayland', native_wayland_dep, gl_glesv2_dep, wsi_egl_dep],
   'x11-gl' : ['glmark2', native_x11_dep, gl_gl_dep, wsi_glx_dep],

--- a/src/native-state-gbm.cpp
+++ b/src/native-state-gbm.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2022 Erico Nunes
+ *
+ * This file is part of the glmark2 OpenGL (ES) 2.0 benchmark.
+ *
+ * glmark2 is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * glmark2 is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * glmark2.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "native-state-gbm.h"
+#include "log.h"
+
+#include <fcntl.h>
+#include <cstring>
+
+bool
+NativeStateGBM::init_display()
+{
+    if (dev_)
+        return true;
+
+    // TODO: The user should be able to define which device node to open.
+    int fd = open("/dev/dri/renderD128", O_RDWR);
+    if (fd < 0) {
+        Log::error("Failed to find a suitable GBM device\n");
+        return false;
+    }
+
+    fd_ = fd;
+
+    dev_ = gbm_create_device(fd_);
+    if (!dev_) {
+        Log::error("Failed to create GBM device\n");
+        return false;
+    }
+
+    signal(SIGINT, &NativeStateGBM::quit_handler);
+
+    return (dev_ != 0);
+}
+
+void*
+NativeStateGBM::display()
+{
+    return static_cast<void*>(dev_);
+}
+
+bool
+NativeStateGBM::create_window(WindowProperties const& properties)
+{
+    if (!dev_) {
+        Log::error("Error: GBM device has not been initialized!\n");
+        return false;
+    }
+
+    width = properties.width;
+    height = properties.height;
+
+    surface_ = gbm_surface_create(dev_, width, height,
+                                  GBM_FORMAT_XRGB8888,
+                                  GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
+    if (!surface_) {
+        Log::error("Failed to create GBM surface\n");
+        return false;
+    }
+
+    return true;
+}
+
+void*
+NativeStateGBM::window(WindowProperties& properties)
+{
+    properties = WindowProperties(width, height, true, 0);
+    return static_cast<void*>(surface_);
+}
+
+void
+NativeStateGBM::visible(bool v)
+{
+    if (!v)
+        return;
+
+    Log::error("visible not supported\n");
+    should_quit_ = true;
+}
+
+volatile std::sig_atomic_t NativeStateGBM::should_quit_(false);
+
+void
+NativeStateGBM::quit_handler(int /*signo*/)
+{
+    should_quit_ = true;
+}
+
+bool
+NativeStateGBM::should_quit()
+{
+    return should_quit_;
+}
+
+void
+NativeStateGBM::flip()
+{
+    Log::error("flip not supported\n");
+    should_quit_ = true;
+}
+
+void
+NativeStateGBM::cleanup()
+{
+    if (surface_) {
+        gbm_surface_destroy(surface_);
+        surface_ = 0;
+    }
+    if (dev_) {
+        gbm_device_destroy(dev_);
+        dev_ = 0;
+    }
+    fd_ = 0;
+}

--- a/src/native-state-gbm.h
+++ b/src/native-state-gbm.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2022 Erico Nunes
+ *
+ * This file is part of the glmark2 OpenGL (ES) 2.0 benchmark.
+ *
+ * glmark2 is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * glmark2 is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * glmark2.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef GLMARK2_NATIVE_STATE_GBM_H_
+#define GLMARK2_NATIVE_STATE_GBM_H_
+
+#include "native-state.h"
+#include <csignal>
+#include <cstring>
+#include <gbm.h>
+
+class NativeStateGBM : public NativeState
+{
+public:
+    NativeStateGBM() :
+        fd_(0),
+        dev_(0),
+        surface_(0) {}
+    ~NativeStateGBM() { cleanup(); }
+
+    bool init_display();
+    void* display();
+    bool create_window(WindowProperties const& properties);
+    void* window(WindowProperties& properties);
+    void visible(bool v);
+    bool should_quit();
+    void flip();
+
+private:
+    static void quit_handler(int signum);
+    static volatile std::sig_atomic_t should_quit_;
+
+    void cleanup();
+
+    int width;
+    int height;
+
+    int fd_;
+    gbm_device* dev_;
+    gbm_surface* surface_;
+};
+
+#endif /* GLMARK2_NATIVE_STATE_GBM_H_ */


### PR DESCRIPTION
glmark2 supports offscreen runs and even gbm already in the case of the drm backend. However, in all cases even with the --off-screen flag, it goes through display or a window system initialization which requires connected hardware or additional environment setup to satisfy that initialization (connected monitor or Xorg or a Wayland compositor running).

This commit adds a simple gbm backend which is purely offscreen and requires no display or window system setup.
The advantage is being able to run on systems with no display-related requirements, and providing GPU benchmark results completely independent of displays.
It is of course not possible to visually see the results though, as is already the case with other offscreen runs.

This is a very similar runtime flow as the drm backend with --off-screen, but does not attempt a connection with DRM to query
parameters such as valid connector or the display resolution.
Additionally, compared to the drm backend this allows any surface size to be specified, not tied to display resolutions.

The benchmark results are equivalent to a run with drm backend and --off-screen for the same surface size, so compatible with current glmark2 scores.

This backend can be helpful in, for instance: development systems, automated test runs, CI environments, or runs on headless remote systems.