### PR TITLE
GLVisualConfig: add multisampling support

### DIFF
--- a/src/canvas-generic.cpp
+++ b/src/canvas-generic.cpp
@@ -146,7 +146,8 @@ CanvasGeneric::print_info()
     ss << "    Surface Config: " << "buf=" << config.buffer
        << " r=" << config.red << " g=" << config.green << " b=" << config.blue
        << " a=" << config.alpha << " depth=" << config.depth
-       << " stencil=" << config.stencil << std::endl;
+       << " stencil=" << config.stencil << " samples=" << config.samples
+       << std::endl;
     ss << "    Surface Size:   " << win_props.width << "x" << win_props.height
        << (win_props.fullscreen ? " fullscreen" : " windowed") << std::endl;
 

--- a/src/gl-state-egl.cpp
+++ b/src/gl-state-egl.cpp
@@ -605,6 +605,7 @@ GLStateEGL::get_glvisualconfig(EGLConfig config, GLVisualConfig& visual_config)
     eglGetConfigAttrib(egl_display_, config, EGL_ALPHA_SIZE, &visual_config.alpha);
     eglGetConfigAttrib(egl_display_, config, EGL_DEPTH_SIZE, &visual_config.depth);
     eglGetConfigAttrib(egl_display_, config, EGL_STENCIL_SIZE, &visual_config.stencil);
+    eglGetConfigAttrib(egl_display_, config, EGL_SAMPLES, &visual_config.samples);
 }
 
 EGLConfig
@@ -654,6 +655,7 @@ GLStateEGL::gotValidConfig()
         EGL_ALPHA_SIZE, requested_visual_config_.alpha,
         EGL_DEPTH_SIZE, requested_visual_config_.depth,
         EGL_STENCIL_SIZE, requested_visual_config_.stencil,
+        EGL_SAMPLES, requested_visual_config_.samples,
 #if GLMARK2_USE_GLESv2
         EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
 #elif GLMARK2_USE_GL

--- a/src/gl-visual-config.cpp
+++ b/src/gl-visual-config.cpp
@@ -26,7 +26,7 @@
 #include <vector>
 
 GLVisualConfig::GLVisualConfig(const std::string &s) :
-    red(1), green(1), blue(1), alpha(1), depth(1), stencil(0), buffer(1)
+    red(1), green(1), blue(1), alpha(1), depth(1), stencil(0), buffer(1), samples(0)
 {
     std::vector<std::string> elems;
 
@@ -54,6 +54,8 @@ GLVisualConfig::GLVisualConfig(const std::string &s) :
                 stencil = Util::fromString<int>(opt[1]);
             else if (opt[0] == "buf" || opt[0] == "buffer")
                 buffer = Util::fromString<int>(opt[1]);
+            else if (opt[0] == "ms" || opt[0] == "samples")
+                samples = Util::fromString<int>(opt[1]);
         }
         else
             Log::info("Warning: ignoring invalid option string '%s' "

--- a/src/gl-visual-config.h
+++ b/src/gl-visual-config.h
@@ -31,7 +31,7 @@ class GLVisualConfig
 {
 public:
     GLVisualConfig():
-        red(1), green(1), blue(1), alpha(1), depth(1), stencil(0), buffer(1) {}
+        red(1), green(1), blue(1), alpha(1), depth(1), stencil(0), buffer(1), samples(0) {}
     GLVisualConfig(int r, int g, int b, int a, int d, int s, int buf):
         red(r), green(g), blue(b), alpha(a), depth(d), stencil(s), buffer(buf) {}
     GLVisualConfig(const std::string &s);
@@ -57,6 +57,7 @@ public:
     int depth;
     int stencil;
     int buffer;
+    int samples;
 
 private:
     int score_component(int component, int target, int scale) const;


### PR DESCRIPTION
This allows to specify a multisampled visual config.