### PR TITLE
X11: add desktop GL flavour with EGL

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -40,7 +40,7 @@ need_gbm = flavors_str.contains('gbm-')
 need_wayland = flavors_str.contains('wayland-')
 need_gl = flavors_str.contains('-gl')
 need_glesv2 = flavors_str.contains('-glesv2')
-need_egl = need_drm or need_wayland or need_glesv2
+need_egl = need_drm or need_wayland or need_glesv2 or flavors_str.contains('-egl')
 need_glx = flavors.contains('x11-gl')
 
 if need_x11

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,7 +7,8 @@ option('flavors', type : 'array',
            'wayland-gl',
            'wayland-glesv2',
            'x11-gl',
-           'x11-glesv2'
+           'x11-glesv2',
+           'x11-gl-egl'
         ],
         value : []
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -257,6 +257,7 @@ flavor_info = {
   'wayland-gl' : ['glmark2-wayland', native_wayland_dep, gl_gl_dep, wsi_egl_dep],
   'wayland-glesv2' : ['glmark2-es2-wayland', native_wayland_dep, gl_glesv2_dep, wsi_egl_dep],
   'x11-gl' : ['glmark2', native_x11_dep, gl_gl_dep, wsi_glx_dep],
+  'x11-gl-egl' : ['glmark2-egl', native_x11_dep, gl_gl_dep, wsi_egl_dep],
   'x11-glesv2' : ['glmark2-es2', native_x11_dep, gl_glesv2_dep, wsi_egl_dep],
 }
 


### PR DESCRIPTION
Sometimes using different GL system (GLX or EGL) has a performance impact, as with GL and GL ES. To better compare desktop GL and GL ES on X11 add x11-gl-egl flavour, which runs on top of EGL, but with desktop GL.

