### PR TITLE
MainLoop,Scene: Support reporting cpu time results

### DIFF
--- a/doc/glmark2.1.in
+++ b/doc/glmark2.1.in
@@ -52,7 +52,7 @@ Size of the output window (default: 800x600)
 Run in fullscreen mode (equivalent to --size -1x-1)
 .TP
 \fB\-\-results\fR RESULTS
-The types of results to report for each benchmark, as a ':' separated list [fps]
+The types of results to report for each benchmark, as a ':' separated list [fps,cpu]
 .TP
 \fB\-\-winsys-options\fR OPTS
 A list of 'opt=value' pairs for window system specific options, separated by ':'

--- a/doc/glmark2.1.in
+++ b/doc/glmark2.1.in
@@ -52,7 +52,7 @@ Size of the output window (default: 800x600)
 Run in fullscreen mode (equivalent to --size -1x-1)
 .TP
 \fB\-\-results\fR RESULTS
-The types of results to report for each benchmark, as a ':' separated list [fps,cpu]
+The types of results to report for each benchmark, as a ':' separated list [fps,cpu,shader]
 .TP
 \fB\-\-winsys-options\fR OPTS
 A list of 'opt=value' pairs for window system specific options, separated by ':'

--- a/doc/glmark2.1.in
+++ b/doc/glmark2.1.in
@@ -51,6 +51,9 @@ Size of the output window (default: 800x600)
 \fB\-\-fullscreen\fR
 Run in fullscreen mode (equivalent to --size -1x-1)
 .TP
+\fB\-\-results\fR RESULTS
+The types of results to report for each benchmark, as a ':' separated list [fps]
+.TP
 \fB\-\-winsys-options\fR OPTS
 A list of 'opt=value' pairs for window system specific options, separated by ':'
 .TP

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -107,8 +107,7 @@ Benchmark::setup_scene()
     scene_.reset_options();
     load_options();
 
-    scene_.load();
-    scene_.setup();
+    scene_.prepare();
 
     return scene_;
 }
@@ -116,8 +115,7 @@ Benchmark::setup_scene()
 void
 Benchmark::teardown_scene()
 {
-    scene_.teardown();
-    scene_.unload();
+    scene_.finish();
 }
 
 bool

--- a/src/main-loop.cpp
+++ b/src/main-loop.cpp
@@ -154,8 +154,11 @@ MainLoop::log_scene_result()
                                          " Set up failed\n");
 
     if (scene_setup_status_ == SceneSetupStatusSuccess) {
-        Log::info(format_fps.c_str(), scene_->average_fps(),
-                                      1000.0 / scene_->average_fps());
+        Scene::Stats stats = scene_->stats();
+
+        Log::info(format_fps.c_str(),
+                  static_cast<unsigned>(ceil(1.0 / stats.average_frame_time)),
+                  1000.0 * stats.average_frame_time);
     }
     else if (scene_setup_status_ == SceneSetupStatusUnsupported) {
         Log::info(format_unsupported.c_str());

--- a/src/main-loop.cpp
+++ b/src/main-loop.cpp
@@ -112,12 +112,12 @@ MainLoop::step()
      * in draw() may have changed the state.
      */
     if (!scene_->running() || should_quit) {
+        (*bench_iter_)->teardown_scene();
         if (scene_setup_status_ == SceneSetupStatusSuccess) {
             score_ += scene_->average_fps();
             benchmarks_run_++;
         }
         log_scene_result();
-        (*bench_iter_)->teardown_scene();
         scene_ = 0;
         next_benchmark();
     }

--- a/src/main-loop.cpp
+++ b/src/main-loop.cpp
@@ -152,6 +152,8 @@ MainLoop::log_scene_result()
                                           " FrameTime: %.3f ms");
     static const std::string format_cpu(Log::continuation_prefix +
                                         " (User: %.3f ms, System: %.3f ms) CpuBusy: %d%%");
+    static const std::string format_shader(Log::continuation_prefix +
+                                           " ShaderCompTime: %.3f ms");
     static const std::string format_unsupported(Log::continuation_prefix +
                                                 " Unsupported\n");
     static const std::string format_fail(Log::continuation_prefix +
@@ -177,6 +179,12 @@ MainLoop::log_scene_result()
                       1000.0 * stats.average_user_time,
                       1000.0 * stats.average_system_time,
                       static_cast<int>(100.0 * stats.cpu_busy_percent));
+        }
+
+        if (Options::results & Options::ResultsShader)
+        {
+            Log::info(format_shader.c_str(),
+                      1000.0 * stats.shader_compilation_time);
         }
 
         if (Options::results == 0)

--- a/src/main-loop.cpp
+++ b/src/main-loop.cpp
@@ -147,18 +147,29 @@ void
 MainLoop::log_scene_result()
 {
     static const std::string format_fps(Log::continuation_prefix +
-                                        " FPS: %u FrameTime: %.3f ms\n");
+                                        " FPS: %u FrameTime: %.3f ms");
     static const std::string format_unsupported(Log::continuation_prefix +
                                                 " Unsupported\n");
     static const std::string format_fail(Log::continuation_prefix +
                                          " Set up failed\n");
+    static const std::string format_done(Log::continuation_prefix + " done");
+    static const std::string format_newline(Log::continuation_prefix + "\n");
 
     if (scene_setup_status_ == SceneSetupStatusSuccess) {
         Scene::Stats stats = scene_->stats();
 
-        Log::info(format_fps.c_str(),
-                  static_cast<unsigned>(ceil(1.0 / stats.average_frame_time)),
-                  1000.0 * stats.average_frame_time);
+        if (Options::results & Options::ResultsFps)
+        {
+            Log::info(format_fps.c_str(),
+                      static_cast<unsigned>(ceil(1.0 / stats.average_frame_time)),
+                      1000.0 * stats.average_frame_time);
+        }
+        else if (Options::results == 0)
+        {
+            Log::info(format_done.c_str());
+        }
+
+        Log::info(format_newline.c_str());
     }
     else if (scene_setup_status_ == SceneSetupStatusUnsupported) {
         Log::info(format_unsupported.c_str());

--- a/src/main-loop.cpp
+++ b/src/main-loop.cpp
@@ -148,6 +148,10 @@ MainLoop::log_scene_result()
 {
     static const std::string format_fps(Log::continuation_prefix +
                                         " FPS: %u FrameTime: %.3f ms");
+    static const std::string format_frame(Log::continuation_prefix +
+                                          " FrameTime: %.3f ms");
+    static const std::string format_cpu(Log::continuation_prefix +
+                                        " (User: %.3f ms, System: %.3f ms)");
     static const std::string format_unsupported(Log::continuation_prefix +
                                                 " Unsupported\n");
     static const std::string format_fail(Log::continuation_prefix +
@@ -164,7 +168,17 @@ MainLoop::log_scene_result()
                       static_cast<unsigned>(ceil(1.0 / stats.average_frame_time)),
                       1000.0 * stats.average_frame_time);
         }
-        else if (Options::results == 0)
+
+        if (Options::results & Options::ResultsCpu)
+        {
+            if (!(Options::results & Options::ResultsFps))
+                Log::info(format_frame.c_str(), 1000.0 * stats.average_frame_time);
+            Log::info(format_cpu.c_str(),
+                      1000.0 * stats.average_user_time,
+                      1000.0 * stats.average_system_time);
+        }
+
+        if (Options::results == 0)
         {
             Log::info(format_done.c_str());
         }

--- a/src/main-loop.cpp
+++ b/src/main-loop.cpp
@@ -151,7 +151,7 @@ MainLoop::log_scene_result()
     static const std::string format_frame(Log::continuation_prefix +
                                           " FrameTime: %.3f ms");
     static const std::string format_cpu(Log::continuation_prefix +
-                                        " (User: %.3f ms, System: %.3f ms)");
+                                        " (User: %.3f ms, System: %.3f ms) CpuBusy: %d%%");
     static const std::string format_unsupported(Log::continuation_prefix +
                                                 " Unsupported\n");
     static const std::string format_fail(Log::continuation_prefix +
@@ -175,7 +175,8 @@ MainLoop::log_scene_result()
                 Log::info(format_frame.c_str(), 1000.0 * stats.average_frame_time);
             Log::info(format_cpu.c_str(),
                       1000.0 * stats.average_user_time,
-                      1000.0 * stats.average_system_time);
+                      1000.0 * stats.average_system_time,
+                      static_cast<int>(100.0 * stats.cpu_busy_percent));
         }
 
         if (Options::results == 0)

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -155,6 +155,8 @@ results_from_str(std::string const& str)
     {
         if (res == "fps")
             results = static_cast<Options::Results>(results | Options::ResultsFps);
+        else if (res == "cpu")
+            results = static_cast<Options::Results>(results | Options::ResultsCpu);
         else
             throw std::runtime_error{"Invalid result type '" + res + "'"};
     }
@@ -215,7 +217,7 @@ Options::print_help()
            "  -s, --size WxH         Size of the output window (default: 800x600)\n"
            "      --fullscreen       Run in fullscreen mode (equivalent to --size -1x-1)\n"
            "      --results RESULTS  The types of results to report for each benchmark,\n"
-           "                         as a ':' separated list [fps]\n"
+           "                         as a ':' separated list [fps,cpu]\n"
            "      --winsys-options O A list of 'opt=value' pairs for window system specific\n"
            "                         options, separated by ':'\n"
            "  -l, --list-scenes      Display information about the available scenes\n"

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -157,6 +157,8 @@ results_from_str(std::string const& str)
             results = static_cast<Options::Results>(results | Options::ResultsFps);
         else if (res == "cpu")
             results = static_cast<Options::Results>(results | Options::ResultsCpu);
+        else if (res == "shader")
+            results = static_cast<Options::Results>(results | Options::ResultsShader);
         else
             throw std::runtime_error{"Invalid result type '" + res + "'"};
     }
@@ -217,7 +219,7 @@ Options::print_help()
            "  -s, --size WxH         Size of the output window (default: 800x600)\n"
            "      --fullscreen       Run in fullscreen mode (equivalent to --size -1x-1)\n"
            "      --results RESULTS  The types of results to report for each benchmark,\n"
-           "                         as a ':' separated list [fps,cpu]\n"
+           "                         as a ':' separated list [fps,cpu,shader]\n"
            "      --winsys-options O A list of 'opt=value' pairs for window system specific\n"
            "                         options, separated by ':'\n"
            "  -l, --list-scenes      Display information about the available scenes\n"

--- a/src/options.h
+++ b/src/options.h
@@ -49,6 +49,10 @@ struct Options {
         SwapModeFIFO,
     };
 
+    enum Results {
+        ResultsFps = 1,
+    };
+
     static bool parse_args(int argc, char **argv);
     static void print_help();
 
@@ -69,6 +73,7 @@ struct Options {
     static bool annotate;
     static bool offscreen;
     static GLVisualConfig visual_config;
+    static Results results;
     static std::vector<WindowSystemOption> winsys_options;
     static std::string winsys_options_help;
 };

--- a/src/options.h
+++ b/src/options.h
@@ -51,6 +51,7 @@ struct Options {
 
     enum Results {
         ResultsFps = 1,
+        ResultsCpu = 2,
     };
 
     static bool parse_args(int argc, char **argv);

--- a/src/options.h
+++ b/src/options.h
@@ -52,6 +52,7 @@ struct Options {
     enum Results {
         ResultsFps = 1,
         ResultsCpu = 2,
+        ResultsShader = 4,
     };
 
     static bool parse_args(int argc, char **argv);

--- a/src/scene-buffer.cpp
+++ b/src/scene-buffer.cpp
@@ -406,9 +406,7 @@ SceneBuffer::update()
 {
     Scene::update();
 
-    double elapsed_time = lastUpdateTime_ - startTime_;
-
-    priv_->wave->update(elapsed_time);
+    priv_->wave->update(realTime_.elapsed());
 }
 
 void

--- a/src/scene-buffer.cpp
+++ b/src/scene-buffer.cpp
@@ -343,25 +343,9 @@ SceneBuffer::supported(bool show_errors)
 }
 
 bool
-SceneBuffer::load()
-{
-    running_ = false;
-
-    return true;
-}
-
-void
-SceneBuffer::unload()
-{
-}
-
-bool
 SceneBuffer::setup()
 {
     using LibMatrix::vec3;
-
-    if (!Scene::setup())
-        return false;
 
     bool interleave = (options_["interleave"].value == "true");
     Mesh::VBOUpdateMethod update_method;
@@ -405,11 +389,6 @@ SceneBuffer::setup()
 
     glDisable(GL_CULL_FACE);
 
-    currentFrame_ = 0;
-    running_ = true;
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    lastUpdateTime_ = startTime_;
-
     return true;
 }
 
@@ -420,8 +399,6 @@ SceneBuffer::teardown()
     priv_->wave = 0;
 
     glEnable(GL_CULL_FACE);
-
-    Scene::teardown();
 }
 
 void

--- a/src/scene-build.cpp
+++ b/src/scene-build.cpp
@@ -199,9 +199,7 @@ SceneBuild::update()
 {
     Scene::update();
 
-    double elapsed_time = lastUpdateTime_ - startTime_;
-
-    rotation_ = rotationSpeed_ * elapsed_time;
+    rotation_ = rotationSpeed_ * realTime_.elapsed();
 }
 
 void

--- a/src/scene-build.cpp
+++ b/src/scene-build.cpp
@@ -70,8 +70,6 @@ SceneBuild::load()
 {
     rotationSpeed_ = 36.0f;
 
-    running_ = false;
-
     return true;
 }
 
@@ -85,9 +83,6 @@ bool
 SceneBuild::setup()
 {
     using LibMatrix::vec3;
-
-    if (!Scene::setup())
-        return false;
 
     /* Set up shaders */
     static const std::string vtx_shader_filename(Options::data_path + "/shaders/light-basic.vert");
@@ -185,11 +180,7 @@ SceneBuild::setup()
 
     program_.start();
 
-    currentFrame_ = 0;
     rotation_ = 0.0;
-    running_ = true;
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    lastUpdateTime_ = startTime_;
 
     return true;
 }
@@ -201,8 +192,6 @@ SceneBuild::teardown()
     program_.release();
 
     mesh_.reset();
-
-    Scene::teardown();
 }
 
 void

--- a/src/scene-bump.cpp
+++ b/src/scene-bump.cpp
@@ -49,8 +49,6 @@ SceneBump::load()
 {
     rotationSpeed_ = 36.0f;
 
-    running_ = false;
-
     return true;
 }
 
@@ -289,9 +287,6 @@ SceneBump::setup_model_height()
 bool
 SceneBump::setup()
 {
-    if (!Scene::setup())
-        return false;
-
     const std::string &bump_render = options_["bump-render"].value;
     Texture::find_textures();
     Model::find_models();
@@ -318,11 +313,7 @@ SceneBump::setup()
     program_["NormalMap"] = 0;
     program_["HeightMap"] = 0;
 
-    currentFrame_ = 0;
     rotation_ = 0.0;
-    running_ = true;
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    lastUpdateTime_ = startTime_;
 
     return true;
 }
@@ -337,8 +328,6 @@ SceneBump::teardown()
 
     glDeleteTextures(1, &texture_);
     texture_ = 0;
-
-    Scene::teardown();
 }
 
 void

--- a/src/scene-bump.cpp
+++ b/src/scene-bump.cpp
@@ -335,9 +335,7 @@ SceneBump::update()
 {
     Scene::update();
 
-    double elapsed_time = lastUpdateTime_ - startTime_;
-
-    rotation_ = rotationSpeed_ * elapsed_time;
+    rotation_ = rotationSpeed_ * realTime_.elapsed();
 }
 
 void

--- a/src/scene-clear.cpp
+++ b/src/scene-clear.cpp
@@ -20,62 +20,8 @@
 //  Jesse Barker
 //
 #include "scene.h"
-#include "util.h"
 
 SceneClear::SceneClear(Canvas& canvas) :
     Scene(canvas, "clear")
 {
-}
-
-bool
-SceneClear::load()
-{
-    running_ = false;
-    return true;
-}
-
-void
-SceneClear::unload()
-{
-}
-
-bool
-SceneClear::setup()
-{
-    if (!Scene::setup())
-        return false;
-
-    // Add scene-specific setup code here
-
-    // Set up the frame timing values and
-    // indicate that the scene is ready to run.
-    running_ = true;
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    lastUpdateTime_ = startTime_;
-    return true;
-}
-
-void
-SceneClear::teardown()
-{
-    // Add scene-specific teardown code here
-    Scene::teardown();
-}
-
-void
-SceneClear::update()
-{
-    Scene::update();
-    // Add scene-specific update code here
-}
-
-void
-SceneClear::draw()
-{
-}
-
-Scene::ValidationResult
-SceneClear::validate()
-{
-    return Scene::ValidationUnknown;
 }

--- a/src/scene-conditionals.cpp
+++ b/src/scene-conditionals.cpp
@@ -114,10 +114,6 @@ SceneConditionals::setup()
     attrib_locations.push_back(program_["position"].location());
     mesh_.set_attrib_locations(attrib_locations);
 
-    running_ = true;
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    lastUpdateTime_ = startTime_;
-
     return true;
 }
 

--- a/src/scene-desktop.cpp
+++ b/src/scene-desktop.cpp
@@ -823,22 +823,8 @@ SceneDesktop::supported(bool show_errors)
 }
 
 bool
-SceneDesktop::load()
-{
-    return true;
-}
-
-void
-SceneDesktop::unload()
-{
-}
-
-bool
 SceneDesktop::setup()
 {
-    if (!Scene::setup())
-        return false;
-
     /* Parse the options */
     unsigned int windows(0);
     unsigned int passes(0);
@@ -906,11 +892,6 @@ SceneDesktop::setup()
      */
     priv_->screen.make_current();
 
-    currentFrame_ = 0;
-    running_ = true;
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    lastUpdateTime_ = startTime_;
-
     return true;
 }
 
@@ -934,8 +915,6 @@ SceneDesktop::teardown()
 
     priv_->desktop.release();
     priv_->screen.release();
-
-    Scene::teardown();
 }
 
 void

--- a/src/scene-desktop.cpp
+++ b/src/scene-desktop.cpp
@@ -921,7 +921,7 @@ void
 SceneDesktop::update()
 {
     double current_time = Util::get_timestamp_us() / 1000000.0;
-    double dt = current_time - lastUpdateTime_;
+    double dt = current_time - realTime_.lastUpdate;
 
     Scene::update();
 

--- a/src/scene-effect-2d.cpp
+++ b/src/scene-effect-2d.cpp
@@ -285,7 +285,6 @@ SceneEffect2D::load()
 {
     Texture::load("effect-2d", &texture_,
                   GL_NEAREST, GL_NEAREST, 0);
-    running_ = false;
 
     return true;
 }
@@ -299,9 +298,6 @@ SceneEffect2D::unload()
 bool
 SceneEffect2D::setup()
 {
-    if (!Scene::setup())
-        return false;
-
     Texture::find_textures();
 
     static const std::string vtx_shader_filename(Options::data_path + "/shaders/effect-2d.vert");
@@ -356,11 +352,6 @@ SceneEffect2D::setup()
     // Load texture sampler value
     program_["Texture0"] = 0;
 
-    currentFrame_ = 0;
-    running_ = true;
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    lastUpdateTime_ = startTime_;
-
     return true;
 }
 
@@ -371,8 +362,6 @@ SceneEffect2D::teardown()
 
     program_.stop();
     program_.release();
-
-    Scene::teardown();
 }
 
 void

--- a/src/scene-function.cpp
+++ b/src/scene-function.cpp
@@ -146,10 +146,6 @@ SceneFunction::setup()
     attrib_locations.push_back(program_["position"].location());
     mesh_.set_attrib_locations(attrib_locations);
 
-    running_ = true;
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    lastUpdateTime_ = startTime_;
-
     return true;
 }
 

--- a/src/scene-grid.cpp
+++ b/src/scene-grid.cpp
@@ -43,7 +43,6 @@ bool
 SceneGrid::load()
 {
     rotationSpeed_ = 36.0f;
-    running_ = false;
 
     return true;
 }
@@ -56,9 +55,6 @@ SceneGrid::unload()
 bool
 SceneGrid::setup()
 {
-    if (!Scene::setup())
-        return false;
-
     int grid_size(Util::fromString<int>(options_["grid-size"].value));
     double grid_length(Util::fromString<double>(options_["grid-length"].value));
 
@@ -77,7 +73,6 @@ SceneGrid::setup()
                     grid_size > 1 ? spacing : 0);
     mesh_.build_vbo();
 
-    currentFrame_ = 0;
     rotation_ = 0.0f;
 
     return true;
@@ -89,8 +84,6 @@ SceneGrid::teardown()
     program_.stop();
     program_.release();
     mesh_.reset();
-
-    Scene::teardown();
 }
 
 void

--- a/src/scene-grid.cpp
+++ b/src/scene-grid.cpp
@@ -91,9 +91,7 @@ SceneGrid::update()
 {
     Scene::update();
 
-    double elapsed_time = lastUpdateTime_ - startTime_;
-
-    rotation_ = rotationSpeed_ * elapsed_time;
+    rotation_ = rotationSpeed_ * realTime_.elapsed();
 }
 
 void

--- a/src/scene-ideas.cpp
+++ b/src/scene-ideas.cpp
@@ -213,35 +213,14 @@ SceneIdeas::~SceneIdeas()
 }
 
 bool
-SceneIdeas::load()
-{
-    running_ = false;
-    return true;
-}
-
-void
-SceneIdeas::unload()
-{
-}
-
-bool
 SceneIdeas::setup()
 {
-    if (!Scene::setup())
-        return false;
-
     priv_ = new SceneIdeasPrivate();
     priv_->initialize(options_);
     if (!priv_->valid())
         return false;
 
     priv_->update_projection(canvas_.projection());
-
-    // Core Scene state
-    currentFrame_ = 0;
-    running_ = true;
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    lastUpdateTime_ = startTime_;
 
     return true;
 }
@@ -410,5 +389,4 @@ SceneIdeas::teardown()
 {
     delete priv_;
     priv_ = 0;
-    Scene::teardown();
 }

--- a/src/scene-jellyfish.cpp
+++ b/src/scene-jellyfish.cpp
@@ -44,33 +44,12 @@ SceneJellyfish::~SceneJellyfish()
 }
 
 bool
-SceneJellyfish::load()
-{
-    running_ = false;
-    return true;
-}
-
-void
-SceneJellyfish::unload()
-{
-}
-
-bool
 SceneJellyfish::setup()
 {
-    if (!Scene::setup())
-        return false;
-
     // Set up our private object that does all of the lifting
     priv_ = new JellyfishPrivate();
     if (!priv_->initialize())
         return false;
-
-    // Set core scene timing after actual initialization so we don't measure
-    // set up time.
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    lastUpdateTime_ = startTime_;
-    running_ = true;
 
     return true;
 }
@@ -81,7 +60,6 @@ SceneJellyfish::teardown()
     priv_->cleanup();
     delete priv_;
     priv_ = 0;
-    Scene::teardown();
 }
 
 void

--- a/src/scene-loop.cpp
+++ b/src/scene-loop.cpp
@@ -143,10 +143,6 @@ SceneLoop::setup()
     attrib_locations.push_back(program_["position"].location());
     mesh_.set_attrib_locations(attrib_locations);
 
-    running_ = true;
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    lastUpdateTime_ = startTime_;
-
     return true;
 }
 

--- a/src/scene-pulsar.cpp
+++ b/src/scene-pulsar.cpp
@@ -167,7 +167,7 @@ ScenePulsar::update()
 {
     Scene::update();
 
-    double elapsed_time = lastUpdateTime_ - startTime_;
+    double elapsed_time = realTime_.elapsed();
 
     for (int i = 0; i < numQuads_; i++) {
         rotations_[i] = rotationSpeeds_[i] * (elapsed_time * 60);

--- a/src/scene-pulsar.cpp
+++ b/src/scene-pulsar.cpp
@@ -64,8 +64,6 @@ ScenePulsar::load()
 {
     scale_ = vec3(1.0, 1.0, 1.0);
 
-    running_ = false;
-
     return true;
 }
 
@@ -77,9 +75,6 @@ ScenePulsar::unload()
 bool
 ScenePulsar::setup()
 {
-    if (!Scene::setup())
-        return false;
-
     // Disable back-face culling
     glDisable(GL_CULL_FACE);
     // Enable alpha blending
@@ -145,12 +140,6 @@ ScenePulsar::setup()
 
     program_.start();
 
-    currentFrame_ = 0;
-
-    running_ = true;
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    lastUpdateTime_ = startTime_;
-
     return true;
 }
 
@@ -171,8 +160,6 @@ ScenePulsar::teardown()
     glDisable(GL_BLEND);
 
     mesh_.reset();
-
-    Scene::teardown();
 }
 
 void

--- a/src/scene-refract.cpp
+++ b/src/scene-refract.cpp
@@ -115,38 +115,14 @@ SceneRefract::supported(bool show_errors)
 }
 
 bool
-SceneRefract::load()
-{
-    running_ = false;
-    return true;
-}
-
-void
-SceneRefract::unload()
-{
-}
-
-bool
 SceneRefract::setup()
 {
-    // If the scene isn't supported, don't bother to go through setup.
-    if (!supported(false) || !Scene::setup())
-    {
-        return false;
-    }
-
     priv_ = new RefractPrivate(canvas_);
     if (!priv_->setup(options_)) {
         delete priv_;
         priv_ = 0;
         return false;
     }
-
-    // Set core scene timing after actual initialization so we don't measure
-    // set up time.
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    lastUpdateTime_ = startTime_;
-    running_ = true;
 
     return true;
 }
@@ -159,7 +135,6 @@ SceneRefract::teardown()
         priv_->teardown();
         delete priv_;
     }
-    Scene::teardown();
 }
 
 void

--- a/src/scene-refract.cpp
+++ b/src/scene-refract.cpp
@@ -142,7 +142,7 @@ SceneRefract::update()
 {
     Scene::update();
     // Add scene-specific update here
-    priv_->update(lastUpdateTime_ - startTime_);
+    priv_->update(realTime_.elapsed());
 }
 
 void

--- a/src/scene-shading.cpp
+++ b/src/scene-shading.cpp
@@ -76,8 +76,6 @@ SceneShading::load()
 {
     rotationSpeed_ = 36.0f;
 
-    running_ = false;
-
     return true;
 }
 
@@ -136,9 +134,6 @@ get_fragment_shader_source(const string& frg_file, unsigned int lights)
 bool
 SceneShading::setup()
 {
-    if (!Scene::setup())
-        return false;
-
     static const LibMatrix::vec4 lightPosition(20.0f, 20.0f, 10.0f, 1.0f);
     static const LibMatrix::vec4 materialDiffuse(0.0f, 0.0f, 1.0f, 1.0f);
 
@@ -261,11 +256,7 @@ SceneShading::setup()
     attrib_locations.push_back(program_["normal"].location());
     mesh_.set_attrib_locations(attrib_locations);
 
-    currentFrame_ = 0;
     rotation_ = 0.0f;
-    running_ = true;
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    lastUpdateTime_ = startTime_;
 
     return true;
 }
@@ -275,8 +266,6 @@ SceneShading::teardown()
 {
     program_.stop();
     program_.release();
-
-    Scene::teardown();
 }
 
 void

--- a/src/scene-shading.cpp
+++ b/src/scene-shading.cpp
@@ -273,9 +273,7 @@ SceneShading::update()
 {
     Scene::update();
 
-    double elapsed_time = lastUpdateTime_ - startTime_;
-
-    rotation_ = rotationSpeed_ * elapsed_time;
+    rotation_ = rotationSpeed_ * realTime_.elapsed();
 }
 
 void

--- a/src/scene-shadow.cpp
+++ b/src/scene-shadow.cpp
@@ -506,37 +506,14 @@ SceneShadow::supported(bool show_errors)
 }
 
 bool
-SceneShadow::load()
-{
-    running_ = false;
-    return true;
-}
-
-void
-SceneShadow::unload()
-{
-}
-
-bool
 SceneShadow::setup()
 {
-    // If the scene isn't supported, don't bother to go through setup.
-    if (!Scene::setup())
-        return false;
-
     priv_ = new ShadowPrivate(canvas_);
     if (!priv_->setup(options_)) {
         delete priv_;
         priv_ = 0;
         return false;
     }
-
-    // Set core scene timing after actual initialization so we don't measure
-    // set up time.
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    lastUpdateTime_ = startTime_;
-    running_ = true;
-
     return true;
 }
 
@@ -548,7 +525,6 @@ SceneShadow::teardown()
         priv_->teardown();
         delete priv_;
     }
-    Scene::teardown();
 }
 
 void

--- a/src/scene-shadow.cpp
+++ b/src/scene-shadow.cpp
@@ -532,7 +532,7 @@ SceneShadow::update()
 {
     Scene::update();
     // Add scene-specific update here
-    priv_->update(lastUpdateTime_ - startTime_);
+    priv_->update(realTime_.elapsed());
 }
 
 void

--- a/src/scene-terrain.cpp
+++ b/src/scene-terrain.cpp
@@ -254,27 +254,8 @@ SceneTerrain::supported(bool show_errors)
 }
 
 bool
-SceneTerrain::load()
-{
-    Scene::load();
-
-    running_ = false;
-
-    return true;
-}
-
-void
-SceneTerrain::unload()
-{
-    Scene::unload();
-}
-
-bool
 SceneTerrain::setup()
 {
-    if (!Scene::setup())
-        return false;
-
     /* Parse options */
     float repeat = Util::fromString<double>(options_["repeat-overlay"].value);
     LibMatrix::vec2 repeat_overlay(repeat, repeat);
@@ -321,10 +302,6 @@ SceneTerrain::setup()
     GLExtensions::BindFramebuffer(GL_FRAMEBUFFER, canvas_.fbo());
     glViewport(0, 0, canvas_.width(), canvas_.height());
 
-    currentFrame_ = 0;
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    running_ = true;
-
     return true;
 }
 
@@ -333,7 +310,6 @@ SceneTerrain::teardown()
 {
     delete priv_;
     priv_ = 0;
-    Scene::teardown();
 }
 
 void

--- a/src/scene-terrain.cpp
+++ b/src/scene-terrain.cpp
@@ -317,8 +317,7 @@ SceneTerrain::update()
 {
     Scene::update();
 
-    double now = Util::get_timestamp_us() / 1000000.0;
-    float diff = now - startTime_;
+    float diff = realTime_.elapsed();
     float scale = priv_->terrain_renderer->repeat_overlay().x() /
                   priv_->height_map_renderer->uv_scale().x();
 

--- a/src/scene-texture.cpp
+++ b/src/scene-texture.cpp
@@ -93,8 +93,6 @@ SceneTexture::load()
 {
     rotationSpeed_ = LibMatrix::vec3(36.0f, 36.0f, 36.0f);
 
-    running_ = false;
-
     return true;
 }
 
@@ -107,9 +105,6 @@ SceneTexture::unload()
 bool
 SceneTexture::setup()
 {
-    if (!Scene::setup())
-        return false;
-
     static const std::string vtx_shader_filename(Options::data_path + "/shaders/light-basic.vert");
     static const std::string vtx_shader_texgen_filename(Options::data_path + "/shaders/light-basic-texgen.vert");
     static const std::string frg_shader_filename(Options::data_path + "/shaders/light-basic-tex.frag");
@@ -250,11 +245,7 @@ SceneTexture::setup()
     }
     mesh_.set_attrib_locations(attrib_locations);
 
-    currentFrame_ = 0;
     rotation_ = LibMatrix::vec3();
-    running_ = true;
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    lastUpdateTime_ = startTime_;
 
     return true;
 }
@@ -266,8 +257,6 @@ SceneTexture::teardown()
     program_.release();
 
     glDeleteTextures(1, &texture_);
-
-    Scene::teardown();
 }
 
 void

--- a/src/scene-texture.cpp
+++ b/src/scene-texture.cpp
@@ -264,9 +264,7 @@ SceneTexture::update()
 {
     Scene::update();
 
-    double elapsed_time = lastUpdateTime_ - startTime_;
-
-    rotation_ = rotationSpeed_ * elapsed_time;
+    rotation_ = rotationSpeed_ * realTime_.elapsed();
 }
 
 void

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -144,6 +144,16 @@ Scene::average_fps()
     return currentFrame_ / elapsed_time;
 }
 
+Scene::Stats
+Scene::stats()
+{
+    Stats stats;
+
+    stats.average_frame_time = (lastUpdateTime_ - startTime_) / currentFrame_;
+
+    return stats;
+}
+
 bool
 Scene::set_option(const string &opt, const string &val)
 {

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -36,6 +36,8 @@ using std::stringstream;
 using std::string;
 using std::map;
 
+double Scene::shaderCompilationTime_ = 0.0;
+
 Scene::Option::Option(const std::string &nam, const std::string &val, const std::string &desc,
                       const std::string &values) :
 name(nam), value(val), default_value(val), description(desc), set(false)
@@ -156,6 +158,7 @@ Scene::stats()
     else
         stats.cpu_busy_percent = 1.0 - idleTime_.elapsed() /
                                        (nproc * realTime_.elapsed());
+    stats.shader_compilation_time = shaderCompilationTime_;
 
     return stats;
 }
@@ -238,6 +241,7 @@ Scene::prepare()
     realTime_.start = realTime_.lastUpdate = 0;
     userTime_.start = userTime_.lastUpdate = 0;
     systemTime_.start = systemTime_.lastUpdate = 0;
+    shaderCompilationTime_ = 0.0;
 
     if (!supported(true))
         return false;
@@ -296,6 +300,8 @@ Scene::load_shaders_from_strings(Program &program,
                                  const std::string &vtx_shader_filename,
                                  const std::string &frg_shader_filename)
 {
+    double shaderStartTime = Util::get_timestamp_us() / 1000000.0;
+
     program.init();
 
     Log::debug("Loading vertex shader from file %s:\n%s",
@@ -331,6 +337,8 @@ Scene::load_shaders_from_strings(Program &program,
         program.release();
         return false;
     }
+
+    shaderCompilationTime_ += Util::get_timestamp_us() / 1000000.0 - shaderStartTime;
 
     return true;
 }

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -42,8 +42,7 @@ name(nam), value(val), default_value(val), description(desc), set(false)
 
 Scene::Scene(Canvas &pCanvas, const string &name) :
     canvas_(pCanvas), name_(name),
-    startTime_(0), lastUpdateTime_(0), currentFrame_(0),
-    running_(0), duration_(0), nframes_(0)
+    currentFrame_(0), running_(0), duration_(0), nframes_(0)
 {
     options_["duration"] = Scene::Option("duration", "10.0",
                                          "The duration of each benchmark in seconds");
@@ -108,14 +107,11 @@ Scene::teardown()
 void
 Scene::update()
 {
-    double current_time = Util::get_timestamp_us() / 1000000.0;
-    double elapsed_time = current_time - startTime_;
+    realTime_.lastUpdate = Util::get_timestamp_us() / 1000000.0;
 
     currentFrame_++;
 
-    lastUpdateTime_ = current_time;
-
-    if (elapsed_time >= duration_)
+    if (realTime_.elapsed() >= duration_)
         running_ = false;
 
     if (nframes_ > 0 && currentFrame_ >= nframes_)
@@ -140,8 +136,7 @@ Scene::info_string(const string &title)
 unsigned
 Scene::average_fps()
 {
-    double elapsed_time = lastUpdateTime_ - startTime_;
-    return currentFrame_ / elapsed_time;
+    return currentFrame_ / realTime_.elapsed();
 }
 
 Scene::Stats
@@ -149,7 +144,7 @@ Scene::stats()
 {
     Stats stats;
 
-    stats.average_frame_time = (lastUpdateTime_ - startTime_) / currentFrame_;
+    stats.average_frame_time = realTime_.elapsed() / currentFrame_;
 
     return stats;
 }
@@ -229,8 +224,7 @@ Scene::prepare()
 
     currentFrame_ = 0;
     running_ = false;
-    startTime_ = 0;
-    lastUpdateTime_ = 0;
+    realTime_.start = realTime_.lastUpdate = 0;
 
     if (!supported(true))
         return false;
@@ -239,8 +233,7 @@ Scene::prepare()
         return false;
 
     running_ = true;
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    lastUpdateTime_ = startTime_;
+    realTime_.start = realTime_.lastUpdate = Util::get_timestamp_us() / 1000000.0;
 
     return true;
 }

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -28,6 +28,7 @@
 #include "util.h"
 #include <sstream>
 #include <algorithm>
+#include <sys/resource.h>
 
 using std::stringstream;
 using std::string;
@@ -145,6 +146,8 @@ Scene::stats()
     Stats stats;
 
     stats.average_frame_time = realTime_.elapsed() / currentFrame_;
+    stats.average_user_time = userTime_.elapsed() / currentFrame_;
+    stats.average_system_time = systemTime_.elapsed() / currentFrame_;
 
     return stats;
 }
@@ -225,6 +228,8 @@ Scene::prepare()
     currentFrame_ = 0;
     running_ = false;
     realTime_.start = realTime_.lastUpdate = 0;
+    userTime_.start = userTime_.lastUpdate = 0;
+    systemTime_.start = systemTime_.lastUpdate = 0;
 
     if (!supported(true))
         return false;
@@ -235,6 +240,8 @@ Scene::prepare()
     running_ = true;
     update_elapsed_times();
     realTime_.start = realTime_.lastUpdate;
+    userTime_.start = userTime_.lastUpdate;
+    systemTime_.start = systemTime_.lastUpdate;
 
     return true;
 }
@@ -323,4 +330,11 @@ void
 Scene::update_elapsed_times()
 {
     realTime_.lastUpdate = Util::get_timestamp_us() / 1000000.0;
+
+    struct rusage usage;
+    getrusage(RUSAGE_SELF, &usage);
+    userTime_.lastUpdate = usage.ru_utime.tv_sec +
+                           usage.ru_utime.tv_usec / 1000000.0;
+    systemTime_.lastUpdate = usage.ru_stime.tv_sec +
+                             usage.ru_stime.tv_usec / 1000000.0;
 }

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -233,7 +233,8 @@ Scene::prepare()
         return false;
 
     running_ = true;
-    realTime_.start = realTime_.lastUpdate = Util::get_timestamp_us() / 1000000.0;
+    update_elapsed_times();
+    realTime_.start = realTime_.lastUpdate;
 
     return true;
 }
@@ -241,6 +242,7 @@ Scene::prepare()
 void
 Scene::finish()
 {
+    update_elapsed_times();
     teardown();
     unload();
 }
@@ -315,4 +317,10 @@ Scene::load_shaders_from_strings(Program &program,
     }
 
     return true;
+}
+
+void
+Scene::update_elapsed_times()
+{
+    realTime_.lastUpdate = Util::get_timestamp_us() / 1000000.0;
 }

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -97,25 +97,7 @@ Scene::unload()
 bool
 Scene::setup()
 {
-    duration_ = Util::fromString<double>(options_["duration"].value);
-    nframes_ = Util::fromString<unsigned>(options_["nframes"].value);
-
-    ShaderSource::default_precision(
-            ShaderSource::Precision(options_["vertex-precision"].value),
-            ShaderSource::ShaderTypeVertex
-            );
-
-    ShaderSource::default_precision(
-            ShaderSource::Precision(options_["fragment-precision"].value),
-            ShaderSource::ShaderTypeFragment
-            );
-
-    currentFrame_ = 0;
-    running_ = false;
-    startTime_ = Util::get_timestamp_us() / 1000000.0;
-    lastUpdateTime_ = startTime_;
-
-    return supported(true);
+    return true;
 }
 
 void
@@ -222,7 +204,35 @@ Scene::set_option_default(const string &opt, const string &val)
 bool
 Scene::prepare()
 {
-    return load() && setup();
+    duration_ = Util::fromString<double>(options_["duration"].value);
+    nframes_ = Util::fromString<unsigned>(options_["nframes"].value);
+
+    ShaderSource::default_precision(
+            ShaderSource::Precision(options_["vertex-precision"].value),
+            ShaderSource::ShaderTypeVertex
+            );
+
+    ShaderSource::default_precision(
+            ShaderSource::Precision(options_["fragment-precision"].value),
+            ShaderSource::ShaderTypeFragment
+            );
+
+    currentFrame_ = 0;
+    running_ = false;
+    startTime_ = 0;
+    lastUpdateTime_ = 0;
+
+    if (!supported(true))
+        return false;
+
+    if (!load() || !setup())
+        return false;
+
+    running_ = true;
+    startTime_ = Util::get_timestamp_us() / 1000000.0;
+    lastUpdateTime_ = startTime_;
+
+    return true;
 }
 
 void

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -219,6 +219,18 @@ Scene::set_option_default(const string &opt, const string &val)
     return true;
 }
 
+bool
+Scene::prepare()
+{
+    return load() && setup();
+}
+
+void
+Scene::finish()
+{
+    teardown();
+    unload();
+}
 
 string
 Scene::construct_title(const string &title)

--- a/src/scene.h
+++ b/src/scene.h
@@ -64,6 +64,10 @@ public:
         bool set;
     };
 
+    struct Stats {
+        double average_frame_time;
+    };
+
     /**
      * The result of a validation check.
      */
@@ -138,6 +142,13 @@ public:
      * @return the average FPS value
      */
     unsigned average_fps();
+
+    /**
+     * Gets the statistics for this scene.
+     *
+     * @return the statistics
+     */
+    Stats stats();
 
     /**
      * Gets the name of the scene.

--- a/src/scene.h
+++ b/src/scene.h
@@ -247,6 +247,11 @@ protected:
      */
     virtual void teardown();
 
+    /**
+     * Updates the elapsed times for this benchmark run.
+     */
+    void update_elapsed_times();
+
     struct ElapsedTime {
         double start = 0.0;
         double lastUpdate = 0.0;

--- a/src/scene.h
+++ b/src/scene.h
@@ -66,6 +66,8 @@ public:
 
     struct Stats {
         double average_frame_time;
+        double average_user_time;
+        double average_system_time;
     };
 
     /**
@@ -262,6 +264,8 @@ protected:
     std::string name_;
     std::map<std::string, Option> options_;
     ElapsedTime realTime_;
+    ElapsedTime userTime_;
+    ElapsedTime systemTime_;
     unsigned currentFrame_;
     bool running_;
     double duration_;      // Duration of run in seconds

--- a/src/scene.h
+++ b/src/scene.h
@@ -68,6 +68,7 @@ public:
         double average_frame_time;
         double average_user_time;
         double average_system_time;
+        double cpu_busy_percent;
     };
 
     /**
@@ -266,6 +267,7 @@ protected:
     ElapsedTime realTime_;
     ElapsedTime userTime_;
     ElapsedTime systemTime_;
+    ElapsedTime idleTime_;
     unsigned currentFrame_;
     bool running_;
     double duration_;      // Duration of run in seconds

--- a/src/scene.h
+++ b/src/scene.h
@@ -255,6 +255,8 @@ class SceneDefaultOptions : public Scene
 public:
     SceneDefaultOptions(Canvas &pCanvas) : Scene(pCanvas, "") {}
     bool set_option(const std::string &opt, const std::string &val);
+
+protected:
     bool setup();
 
 private:
@@ -265,10 +267,6 @@ class SceneBuild : public Scene
 {
 public:
     SceneBuild(Canvas &pCanvas);
-    bool load();
-    void unload();
-    bool setup();
-    void teardown();
     void update();
     void draw();
     ValidationResult validate();
@@ -276,6 +274,11 @@ public:
     ~SceneBuild();
 
 protected:
+    bool load();
+    void unload();
+    bool setup();
+    void teardown();
+
     Program program_;
     LibMatrix::mat4 perspective_;
     LibMatrix::vec3 centerVec_;
@@ -293,10 +296,6 @@ class SceneTexture : public Scene
 {
 public:
     SceneTexture(Canvas &pCanvas);
-    bool load();
-    void unload();
-    bool setup();
-    void teardown();
     void update();
     void draw();
     ValidationResult validate();
@@ -304,6 +303,11 @@ public:
     ~SceneTexture();
 
 protected:
+    bool load();
+    void unload();
+    bool setup();
+    void teardown();
+
     Program program_;
     Mesh mesh_;
     GLuint texture_;
@@ -321,10 +325,6 @@ class SceneShading : public Scene
 {
 public:
     SceneShading(Canvas &pCanvas);
-    bool load();
-    void unload();
-    bool setup();
-    void teardown();
     void update();
     void draw();
     ValidationResult validate();
@@ -332,6 +332,11 @@ public:
     ~SceneShading();
 
 protected:
+    bool load();
+    void unload();
+    bool setup();
+    void teardown();
+
     Program program_;
     float radius_;
     bool orientModel_;
@@ -348,17 +353,18 @@ class SceneGrid : public Scene
 {
 public:
     SceneGrid(Canvas &pCanvas, const std::string &name);
-    virtual bool load();
-    virtual void unload();
-    virtual bool setup();
-    virtual void teardown();
-    virtual void update();
-    virtual void draw();
+    void update();
+    void draw();
     virtual ValidationResult validate();
 
     ~SceneGrid();
 
 protected:
+    bool load();
+    void unload();
+    bool setup();
+    void teardown();
+
     Program program_;
     Mesh mesh_;
     float rotation_;
@@ -369,40 +375,42 @@ class SceneConditionals : public SceneGrid
 {
 public:
     SceneConditionals(Canvas &pCanvas);
-    bool setup();
     ValidationResult validate();
 
     ~SceneConditionals();
+
+protected:
+    bool setup();
 };
 
 class SceneFunction : public SceneGrid
 {
 public:
     SceneFunction(Canvas &pCanvas);
-    bool setup();
     ValidationResult validate();
 
     ~SceneFunction();
+
+protected:
+    bool setup();
 };
 
 class SceneLoop : public SceneGrid
 {
 public:
     SceneLoop(Canvas &pCanvas);
-    bool setup();
     ValidationResult validate();
 
     ~SceneLoop();
+
+protected:
+    bool setup();
 };
 
 class SceneBump : public Scene
 {
 public:
     SceneBump(Canvas &pCanvas);
-    bool load();
-    void unload();
-    bool setup();
-    void teardown();
     void update();
     void draw();
     ValidationResult validate();
@@ -410,6 +418,11 @@ public:
     ~SceneBump();
 
 protected:
+    bool load();
+    void unload();
+    bool setup();
+    void teardown();
+
     Program program_;
     Mesh mesh_;
     GLuint texture_;
@@ -426,10 +439,6 @@ class SceneEffect2D : public Scene
 {
 public:
     SceneEffect2D(Canvas &pCanvas);
-    bool load();
-    void unload();
-    bool setup();
-    void teardown();
     void update();
     void draw();
     ValidationResult validate();
@@ -437,8 +446,12 @@ public:
     ~SceneEffect2D();
 
 protected:
-    Program program_;
+    bool load();
+    void unload();
+    bool setup();
+    void teardown();
 
+    Program program_;
     Mesh mesh_;
     GLuint texture_;
 };
@@ -447,10 +460,6 @@ class ScenePulsar : public Scene
 {
 public:
     ScenePulsar(Canvas &pCanvas);
-    bool load();
-    void unload();
-    bool setup();
-    void teardown();
     void update();
     void draw();
     ValidationResult validate();
@@ -458,6 +467,11 @@ public:
     ~ScenePulsar();
 
 protected:
+    bool load();
+    void unload();
+    bool setup();
+    void teardown();
+
     int numQuads_;
     Program program_;
     Mesh mesh_;
@@ -477,15 +491,15 @@ class SceneDesktop : public Scene
 public:
     SceneDesktop(Canvas &canvas);
     bool supported(bool show_errors);
-    bool load();
-    void unload();
-    bool setup();
-    void teardown();
     void update();
     void draw();
     ValidationResult validate();
 
     ~SceneDesktop();
+
+protected:
+    bool setup();
+    void teardown();
 
 private:
     SceneDesktopPrivate *priv_;
@@ -498,10 +512,6 @@ class SceneBuffer : public Scene
 public:
     SceneBuffer(Canvas &canvas);
     bool supported(bool show_errors);
-    bool load();
-    void unload();
-    bool setup();
-    void teardown();
     void update();
     void draw();
     ValidationResult validate();
@@ -509,6 +519,8 @@ public:
     ~SceneBuffer();
 
 private:
+    bool setup();
+    void teardown();
     SceneBufferPrivate *priv_;
 };
 
@@ -518,15 +530,15 @@ class SceneIdeas : public Scene
 {
 public:
     SceneIdeas(Canvas &pCanvas);
-    bool load();
-    void unload();
-    bool setup();
-    void teardown();
     void update();
     void draw();
     ValidationResult validate();
 
     ~SceneIdeas();
+
+protected:
+    bool setup();
+    void teardown();
 
 private:
     SceneIdeasPrivate* priv_;
@@ -539,15 +551,15 @@ class SceneTerrain : public Scene
 public:
     SceneTerrain(Canvas &pCanvas);
     bool supported(bool show_errors);
-    bool load();
-    void unload();
-    bool setup();
-    void teardown();
     void update();
     void draw();
     ValidationResult validate();
 
     ~SceneTerrain();
+
+protected:
+    bool setup();
+    void teardown();
 
 private:
     SceneTerrainPrivate* priv_;
@@ -560,13 +572,13 @@ class SceneJellyfish : public Scene
 public:
     SceneJellyfish(Canvas &pCanvas);
     ~SceneJellyfish();
-    bool load();
-    void unload();
-    bool setup();
-    void teardown();
     void update();
     void draw();
     ValidationResult validate();
+
+protected:
+    bool setup();
+    void teardown();
 };
 
 class ShadowPrivate;
@@ -576,13 +588,13 @@ class SceneShadow : public Scene
 public:
     SceneShadow(Canvas& canvas);
     bool supported(bool show_errors);
-    bool load();
-    void unload();
-    bool setup();
-    void teardown();
     void update();
     void draw();
     ValidationResult validate();
+
+protected:
+    bool setup();
+    void teardown();
 };
 
 class RefractPrivate;
@@ -592,26 +604,19 @@ class SceneRefract : public Scene
 public:
     SceneRefract(Canvas& canvas);
     bool supported(bool show_errors);
-    bool load();
-    void unload();
-    bool setup();
-    void teardown();
     void update();
     void draw();
     ValidationResult validate();
+
+protected:
+    bool setup();
+    void teardown();
 };
 
 class SceneClear : public Scene
 {
 public:
     SceneClear(Canvas &pCanvas);
-    bool load();
-    void unload();
-    bool setup();
-    void teardown();
-    void update();
-    void draw();
-    ValidationResult validate();
 };
 
 #endif

--- a/src/scene.h
+++ b/src/scene.h
@@ -83,44 +83,6 @@ public:
     virtual bool supported(bool show_errors);
 
     /**
-     * Performs option-independent resource loading and configuration.
-     *
-     * It should be safe to call ::load() (and the corresponding ::unload())
-     * only once per program execution, although you may choose to do so more
-     * times to better manage resource consumption.
-     *
-     * @return whether loading succeeded
-     */
-    virtual bool load();
-
-    /**
-     * Performs option-independent resource unloading.
-     */
-    virtual void unload();
-
-    /**
-     * Performs option-dependent resource loading and configuration.
-     *
-     * This method also prepares a scene for a benchmark run.
-     * It should be called just before running a scene/benchmark.
-     *
-     * The base Scene::setup() method also checks whether a scene
-     * configuration is supported by calling ::supported(true).
-     *
-     * @return whether setting the scene up succeeded
-     */
-    virtual bool setup();
-
-    /**
-     * Performs option-dependent resource unloading.
-     *
-     * This method should be called just after running a scene/benchmark.
-     *
-     * @return the operation status
-     */
-    virtual void teardown();
-
-    /**
      * Updates the scene state.
      */
     virtual void update();
@@ -201,6 +163,16 @@ public:
     const std::map<std::string, Option> &options() { return options_; }
 
     /**
+     * Prepare for a benchmarking run.
+     */
+    bool prepare();
+
+    /**
+     * Finish a benchmarking run.
+     */
+    void finish();
+
+    /**
      * Gets a dummy scene object reference.
      *
      * @return the dummy Scene
@@ -225,6 +197,44 @@ public:
 protected:
     Scene(Canvas &pCanvas, const std::string &name);
     std::string construct_title(const std::string &title);
+
+    /**
+     * Performs option-independent resource loading and configuration.
+     *
+     * It should be safe to call ::load() (and the corresponding ::unload())
+     * only once per program execution, although you may choose to do so more
+     * times to better manage resource consumption.
+     *
+     * @return whether loading succeeded
+     */
+    virtual bool load();
+
+    /**
+     * Performs option-independent resource unloading.
+     */
+    virtual void unload();
+
+    /**
+     * Performs option-dependent resource loading and configuration.
+     *
+     * This method also prepares a scene for a benchmark run.
+     * It should be called just before running a scene/benchmark.
+     *
+     * The base Scene::setup() method also checks whether a scene
+     * configuration is supported by calling ::supported(true).
+     *
+     * @return whether setting the scene up succeeded
+     */
+    virtual bool setup();
+
+    /**
+     * Performs option-dependent resource unloading.
+     *
+     * This method should be called just after running a scene/benchmark.
+     *
+     * @return the operation status
+     */
+    virtual void teardown();
 
     Canvas &canvas_;
     std::string name_;

--- a/src/scene.h
+++ b/src/scene.h
@@ -247,11 +247,16 @@ protected:
      */
     virtual void teardown();
 
+    struct ElapsedTime {
+        double start = 0.0;
+        double lastUpdate = 0.0;
+        double elapsed() { return lastUpdate - start; }
+    };
+
     Canvas &canvas_;
     std::string name_;
     std::map<std::string, Option> options_;
-    double startTime_;
-    double lastUpdateTime_;
+    ElapsedTime realTime_;
     unsigned currentFrame_;
     bool running_;
     double duration_;      // Duration of run in seconds

--- a/src/scene.h
+++ b/src/scene.h
@@ -69,6 +69,7 @@ public:
         double average_user_time;
         double average_system_time;
         double cpu_busy_percent;
+        double shader_compilation_time;
     };
 
     /**
@@ -261,6 +262,7 @@ protected:
         double elapsed() { return lastUpdate - start; }
     };
 
+    static double shaderCompilationTime_;
     Canvas &canvas_;
     std::string name_;
     std::map<std::string, Option> options_;


### PR DESCRIPTION
Add the `--results` command-line option to allow configuring the kinds of results to show for each benchmark. The options are:

-  `fps`: FPS and frame time
- `cpu`: frame time, user/system time per frame, cpu busy percent
- `shader`: total shader compilation time