### PR TITLE
NativeStateX11: Add winsys option for position

### DIFF
--- a/src/native-state-x11.h
+++ b/src/native-state-x11.h
@@ -29,7 +29,7 @@
 class NativeStateX11 : public NativeState
 {
 public:
-    NativeStateX11() : xdpy_(0), xwin_(0), properties_() {}
+    NativeStateX11();
     ~NativeStateX11();
 
     bool init_display();


### PR DESCRIPTION
Not all windowing system support global coordinates, but X11 does and some use cases might benefit from being able to locate the window on screen.

Add a new winsys option "position=x,y" to instruct the X11 windowing system to place the output window at the given location.