### PR TITLE
src/meson.build: add x11 dependency to glx

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -245,6 +245,7 @@ if need_glx
             include_directories('libmatrix'),
             ],
         compile_args: ['-DGLMARK2_USE_GLX'],
+        dependencies: x11_dep,
         )
 else
     wsi_glx_dep = declare_dependency()


### PR DESCRIPTION
glad/src/glx.c includes glad/include/glad/glx.h includes X11/X.h and friends.