### PR TITLE
Change failure to get a "good" visual config to warning

### DIFF
--- a/src/gl-state-egl.cpp
+++ b/src/gl-state-egl.cpp
@@ -635,7 +635,10 @@ GLStateEGL::select_best_config(std::vector<EGLConfig>& configs)
         }
     }
 
-    return best_score > 0 ? best_config : 0;
+    if (best_score <= 0) {
+        Log::error("Unable to find good EGL FB config (best match %d)\n", best_config);
+    }
+    return best_config;
 }
 
 bool

--- a/src/gl-state-glx.cpp
+++ b/src/gl-state-glx.cpp
@@ -342,7 +342,10 @@ GLStateGLX::select_best_config(std::vector<GLXFBConfig> configs)
         }
     }
 
-    return best_score > 0 ? best_config : 0;
+    if (best_score <= 0) {
+        Log::error("Unable to find good GLX FB config (best match %d)\n", best_config);
+    }
+    return best_config;
 }
 
 GLADapiproc


### PR DESCRIPTION
With ea488e9 glmark2 was adjusted to abort if it could not find a "good" EGL or GLX config

This commit changes that to instead warn and continue in that case

Fixes glmark2 running on at least NetBSD-10/amd64 on a ThinkPad T530, and should also address issue#202 for Ubuntu 22.04 on arm64