### PR TITLE
GLStateEGL,GLStateGLX: Fix the failure to find suitable FB config

### DIFF
--- a/src/gl-state-egl.cpp
+++ b/src/gl-state-egl.cpp
@@ -635,7 +635,7 @@ GLStateEGL::select_best_config(std::vector<EGLConfig>& configs)
         }
     }
 
-    return best_score > 0 ? best_config : 0;
+    return best_score > INT_MIN ? best_config : 0;
 }
 
 bool

--- a/src/gl-state-glx.cpp
+++ b/src/gl-state-glx.cpp
@@ -342,7 +342,7 @@ GLStateGLX::select_best_config(std::vector<GLXFBConfig> configs)
         }
     }
 
-    return best_score > 0 ? best_config : 0;
+    return best_score > INT_MIN ? best_config : 0;
 }
 
 GLADapiproc


### PR DESCRIPTION
It does not make sense that ``select_best_config()`` returns NULL from matched FB configs even if there is only one config which gets a negative score in the list. For example, on my WSL2 Ubuntu-20.04, that situation mentioned occurs.

    Debug: Found 1 matching FB configs.
    Debug: matched FB config score -785.
    Debug: GLX chosen config ID: 0x23 Native Visual ID: 0x23
    Debug:   Buffer: 24 bits
    Debug:      Red: 8 bits
    Debug:    Green: 8 bits
    Debug:     Blue: 8 bits
    Debug:    Alpha: 8 bits
    Debug:    Depth: 0 bits
    Debug:  Stencil: 0 bits
    Debug:  Samples: 0
    Debug: Creating XWindow W: 800 H: 600 VisualID: 0x23

And with this patch applied, glmark2 will run like a charm for me.