### PR TITLE
Add --default-options for all benchmarks

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -22,6 +22,7 @@
 
 #include "benchmark.h"
 #include "log.h"
+#include "options.h"
 #include "util.h"
 
 using std::string;
@@ -42,32 +43,6 @@ get_scene_from_description(const string &s)
     return Benchmark::get_scene_by_name(name);
 }
 
-static vector<Benchmark::OptionPair>
-get_options_from_description(const string &s)
-{
-    vector<Benchmark::OptionPair> options;
-    vector<string> elems;
-
-    Util::split(s, ':', elems, Util::SplitModeNormal);
-
-    for (vector<string>::const_iterator iter = elems.begin() + 1;
-         iter != elems.end();
-         iter++)
-    {
-        vector<string> opt;
-
-        Util::split(*iter, '=', opt, Util::SplitModeNormal);
-        if (opt.size() == 2)
-            options.push_back(Benchmark::OptionPair(opt[0], opt[1]));
-        else
-            Log::info("Warning: ignoring invalid option string '%s' "
-                      "in benchmark description\n",
-                      iter->c_str());
-    }
-
-    return options;
-}
-
 void
 Benchmark::register_scene(Scene &scene)
 {
@@ -85,19 +60,19 @@ Benchmark::get_scene_by_name(const string &name)
         return Scene::dummy();
 }
 
-Benchmark::Benchmark(Scene &scene, const vector<OptionPair> &options) :
+Benchmark::Benchmark(Scene &scene, const vector<Options::Pair> &options) :
     scene_(scene), options_(options)
 {
 }
 
-Benchmark::Benchmark(const string &name, const vector<OptionPair> &options) :
+Benchmark::Benchmark(const string &name, const vector<Options::Pair> &options) :
     scene_(Benchmark::get_scene_by_name(name)), options_(options)
 {
 }
 
 Benchmark::Benchmark(const string &s) :
     scene_(get_scene_from_description(s)),
-    options_(get_options_from_description(s))
+    options_(Options::get_options_from_description(s, 1))
 {
 }
 
@@ -121,12 +96,12 @@ Benchmark::teardown_scene()
 bool
 Benchmark::needs_decoration() const
 {
-    for (vector<OptionPair>::const_iterator iter = options_.begin();
+    for (vector<Options::Pair>::const_iterator iter = options_.begin();
          iter != options_.end();
          iter++)
     {
-        if ((iter->first == "show-fps" && iter->second == "true") ||
-            (iter->first == "title" && !iter->second.empty()))
+        if ((iter->name == "show-fps" && iter->value == "true") ||
+            (iter->name == "title" && !iter->value.empty()))
         {
             return true;
         }
@@ -138,20 +113,27 @@ Benchmark::needs_decoration() const
 void
 Benchmark::load_options()
 {
-    for (vector<OptionPair>::iterator iter = options_.begin();
+    for (vector<Options::Pair>::iterator iter = Options::default_options.begin();
+         iter != Options::default_options.end();
+         iter++)
+    {
+        scene_.set_option(iter->name, iter->value);
+    }
+
+    for (vector<Options::Pair>::iterator iter = options_.begin();
          iter != options_.end();
          iter++)
     {
-        if (!scene_.set_option(iter->first, iter->second)) {
-            map<string, Scene::Option>::const_iterator opt_iter = scene_.options().find(iter->first);
+        if (!scene_.set_option(iter->name, iter->value)) {
+            map<string, Scene::Option>::const_iterator opt_iter = scene_.options().find(iter->name);
 
             if (opt_iter == scene_.options().end()) {
                 Log::info("Warning: Scene '%s' doesn't accept option '%s'\n",
-                          scene_.name().c_str(), iter->first.c_str());
+                          scene_.name().c_str(), iter->name.c_str());
             }
             else {
                 Log::info("Warning: Scene '%s' doesn't accept value '%s' for option '%s'\n",
-                          scene_.name().c_str(), iter->second.c_str(), iter->first.c_str());
+                          scene_.name().c_str(), iter->value.c_str(), iter->name.c_str());
             }
         }
     }

--- a/src/benchmark.h
+++ b/src/benchmark.h
@@ -26,6 +26,7 @@
 #include <string>
 #include <map>
 
+#include "options.h"
 #include "scene.h"
 
 /**
@@ -36,15 +37,13 @@
 class Benchmark
 {
 public:
-    typedef std::pair<std::string, std::string> OptionPair;
-
     /**
      * Creates a benchmark using a scene object reference.
      *
      * @param scene the scene to use
      * @param options the options to use
      */
-    Benchmark(Scene &scene, const std::vector<OptionPair> &options);
+    Benchmark(Scene &scene, const std::vector<Options::Pair> &options);
 
     /**
      * Creates a benchmark using a scene name.
@@ -55,7 +54,7 @@ public:
      * @param name the name of the scene to use
      * @param options the options to use
      */
-    Benchmark(const std::string &name, const std::vector<OptionPair> &options);
+    Benchmark(const std::string &name, const std::vector<Options::Pair> &options);
 
     /**
      * Creates a benchmark from a description string.
@@ -116,7 +115,7 @@ public:
 
 private:
     Scene &scene_;
-    std::vector<OptionPair> options_;
+    std::vector<Options::Pair> options_;
 
     void load_options();
 

--- a/src/options.h
+++ b/src/options.h
@@ -29,7 +29,7 @@
 #include "gl-visual-config.h"
 
 struct Options {
-    struct WindowSystemOption {
+    struct Pair {
         std::string name;
         std::string value;
     };
@@ -55,6 +55,7 @@ struct Options {
         ResultsShader = 4,
     };
 
+    static std::vector<Pair> get_options_from_description(const std::string &s, int skip);
     static bool parse_args(int argc, char **argv);
     static void print_help();
 
@@ -78,8 +79,9 @@ struct Options {
     static bool good_config;
     static Results results;
     static std::string results_file;
-    static std::vector<WindowSystemOption> winsys_options;
+    static std::vector<Pair> winsys_options;
     static std::string winsys_options_help;
+    static std::vector<Pair> default_options;
 };
 
 #endif /* OPTIONS_H_ */


### PR DESCRIPTION
Accepts same format as for for --benchmark, for example:
    $ glmark2 --default-options=nframes=10:show-fps=true

Specified options will be used by default for all benchmarks, unless overridden in the specific --benchmark description, which has higher priority.

Also merged winsys_options_from_str() with get_options_from_description(), which have same implementation.