### PR TITLE
Fix memory leaks using smart pointers

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -873,8 +873,8 @@ Model::find_models()
         }
 
         string name(curPath, namePos, extPos - namePos);
-        ModelDescriptor* desc = new ModelDescriptor(name, format, curPath);
-        ModelPrivate::modelMap.insert(std::make_pair(name, desc));
+        std::unique_ptr<ModelDescriptor> desc(new ModelDescriptor(name, format, curPath));
+        ModelPrivate::modelMap.insert(std::make_pair(name, std::move(desc)));
     }
 
     return ModelPrivate::modelMap;
@@ -900,7 +900,7 @@ Model::load(const string& modelName)
         return retVal;
     }
 
-    ModelDescriptor* desc = modelIt->second;
+    ModelDescriptor* desc = modelIt->second.get();
     switch (desc->format())
     {
         case MODEL_INVALID:

--- a/src/model.h
+++ b/src/model.h
@@ -29,6 +29,7 @@
 #include <vector>
 #include <map>
 #include "vec.h"
+#include <memory>
 
 // Forward declare the mesh object.  We don't need the whole header here.
 class Mesh;
@@ -60,7 +61,7 @@ public:
     ModelFormat format() const { return format_; }
 };
 
-typedef std::map<std::string, ModelDescriptor*> ModelMap;
+typedef std::map<std::string, std::unique_ptr<ModelDescriptor>> ModelMap;
 
 /**
  * A model as loaded from a 3D object data file.

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -111,7 +111,7 @@ Texture::load(const std::string &textureName, GLuint *pTexture, ...)
     }
 
     // Pull the pathname out of the descriptor and use it for the PNG load.
-    TextureDescriptor* desc = textureIt->second;
+    TextureDescriptor* desc = textureIt->second.get();
     const std::string& filename = desc->pathname();
     ImageData image;
 
@@ -206,8 +206,8 @@ Texture::find_textures()
         }
 
         string name(curPath, namePos, extPos - namePos);
-        TextureDescriptor* desc = new TextureDescriptor(name, curPath, type);
-        TexturePrivate::textureMap.insert(std::make_pair(name, desc));
+        std::unique_ptr<TextureDescriptor> desc(new TextureDescriptor(name, curPath, type));
+        TexturePrivate::textureMap.insert(std::make_pair(name, std::move(desc)));
     }
 
     return TexturePrivate::textureMap;

--- a/src/texture.h
+++ b/src/texture.h
@@ -28,6 +28,7 @@
 
 #include <string>
 #include <map>
+#include <memory>
 
 /**
  * A descriptor for a texture file.
@@ -56,7 +57,7 @@ private:
     TextureDescriptor();
 };
 
-typedef std::map<std::string, TextureDescriptor*> TextureMap;
+typedef std::map<std::string, std::unique_ptr<TextureDescriptor>> TextureMap;
 
 class Texture
 {


### PR DESCRIPTION
I discovered this issue while using ASan (AddressSanitizer) and Valgrind. There were memory leak problems with the insertion of TextureDescriptor and ModelDescriptor. Moreover, the related map is a global variable, and using smart pointers can better constrain the lifecycle, preventing false positives from ASan.