### PR TITLE
Increment versionCode for the Android build

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      android:versionCode="1"
+      android:versionCode="2"
       android:versionName="2023.01" package="org.linaro.glmark2">
     <application android:icon="@mipmap/ic_launcher"
                  android:label="@string/app_name"


### PR DESCRIPTION
Otherwise F-Droid does not know that a new version has been tagged and doesn't publish the update.

This will only take effect after a new tag has been made though, and future tags after the next one will need to increment versionCode like this again as well.

Issue report on F-Droid side for reference: https://gitlab.com/fdroid/fdroiddata/-/issues/3191