### PR TITLE
Enable exceptions support in the Android build

### DIFF
--- a/android/jni/Application.mk
+++ b/android/jni/Application.mk
@@ -2,3 +2,4 @@ APP_ABI := all
 APP_STL := c++_static
 APP_PLATFORM := android-16
 APP_BUILD_SCRIPT := jni/Android.ndk.mk
+APP_CPPFLAGS += -fexceptions


### PR DESCRIPTION
The code started using them since a20881a17c172eed94ba60a45131c5df606467ea, but the Android build appears to disable them by default so we need to enable it explicitly.