### PR TITLE
NativeStateX11: Fix WM_DELETE_WINDOW handling

### DIFF
--- a/src/native-state-x11.cpp
+++ b/src/native-state-x11.cpp
@@ -231,8 +231,8 @@ NativeStateX11::create_window(WindowProperties const& properties)
     XStoreName(xdpy_ , xwin_,  win_name);
 
     /* Gracefully handle Window Delete event from window manager */
-    Atom wmDelete = XInternAtom(xdpy_, "WM_DELETE_WINDOW", True);
-    XSetWMProtocols(xdpy_, xwin_, &wmDelete, 1);
+    wm_delete_window_ = XInternAtom(xdpy_, "WM_DELETE_WINDOW", True);
+    XSetWMProtocols(xdpy_, xwin_, &wm_delete_window_, 1);
 
     return true;
 }
@@ -266,8 +266,10 @@ NativeStateX11::should_quit()
             return true;
     }
     else if (event.type == ClientMessage) {
-        /* Window Delete event from window manager */
-        return true;
+        if ((Atom)event.xclient.data.l[0] == wm_delete_window_) {
+            /* Window Delete event from window manager */
+            return true;
+        }
     }
 
     return false;

--- a/src/native-state-x11.h
+++ b/src/native-state-x11.h
@@ -46,6 +46,8 @@ private:
     /** The X window associated with this canvas. */
     Window xwin_;
     WindowProperties properties_;
+    /** The X WM_DELETE message. */
+    Atom wm_delete_window_;
 };
 
 #endif /* GLMARK2_NATIVE_STATE_X11_H_ */


### PR DESCRIPTION
ClientMessages may not necessarily always be the expected delete message, so always verify the Atom first.

Fixes #207