### PR TITLE
libmatrix: Provide a copy of the va_list to __android_log_vprint

### DIFF
--- a/src/libmatrix/log.cc
+++ b/src/libmatrix/log.cc
@@ -103,6 +103,16 @@ print_prefixed_message(std::ostream& stream, const string& color, const string& 
     delete[] buf;
 }
 
+#ifdef ANDROID
+static void
+android_vlog(int prio, const char *tag, const char *fmt, va_list ap)
+{
+    va_list aq;
+    va_copy(aq, ap);
+    __android_log_vprint(prio, tag, fmt, aq);
+    va_end(aq);
+}
+#endif
 
 void
 Log::info(const char *fmt, ...)
@@ -117,7 +127,7 @@ Log::info(const char *fmt, ...)
     const string& color(do_debug_ ? infocolor : empty);
     print_prefixed_message(std::cout, color, prefix, fmt, ap);
 #else
-    __android_log_vprint(ANDROID_LOG_INFO, appname_.c_str(), fmt, ap);
+    android_vlog(ANDROID_LOG_INFO, appname_.c_str(), fmt, ap);
 #endif
 
     if (extra_out_)
@@ -139,7 +149,7 @@ Log::debug(const char *fmt, ...)
     static const string& dbgcolor(isatty(fileno(stdout)) ? terminal_color_yellow : empty);
     print_prefixed_message(std::cout, dbgcolor, dbgprefix, fmt, ap);
 #else
-    __android_log_vprint(ANDROID_LOG_DEBUG, appname_.c_str(), fmt, ap);
+    android_vlog(ANDROID_LOG_DEBUG, appname_.c_str(), fmt, ap);
 #endif
 
     if (extra_out_)
@@ -159,7 +169,7 @@ Log::error(const char *fmt, ...)
     static const string& errcolor(isatty(fileno(stderr)) ? terminal_color_red : empty);
     print_prefixed_message(std::cerr, errcolor, errprefix, fmt, ap);
 #else
-    __android_log_vprint(ANDROID_LOG_ERROR, appname_.c_str(), fmt, ap);
+    android_vlog(ANDROID_LOG_ERROR, appname_.c_str(), fmt, ap);
 #endif
 
     if (extra_out_)
@@ -179,7 +189,7 @@ Log::warning(const char *fmt, ...)
     static const string& warncolor(isatty(fileno(stderr)) ? terminal_color_magenta : empty);
     print_prefixed_message(std::cerr, warncolor, warnprefix, fmt, ap);
 #else
-    __android_log_vprint(ANDROID_LOG_WARN, appname_.c_str(), fmt, ap);
+    android_vlog(ANDROID_LOG_WARN, appname_.c_str(), fmt, ap);
 #endif
 
     if (extra_out_)


### PR DESCRIPTION
The orignal va_list may be used for the extra_out_ stream so it needs to remain valid.

Fixes #218