### PR TITLE
x11: Correctly set fullscreen size using Xrandr

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -46,6 +46,7 @@ endif
 
 if need_x11
     x11_dep = dependency('x11')
+    xrandr_dep = dependency('xrandr')
 endif
 
 if need_drm

--- a/src/meson.build
+++ b/src/meson.build
@@ -168,7 +168,7 @@ if need_x11
     native_x11_lib = static_library(
         'native-x11',
         'native-state-x11.cpp',
-        dependencies: [x11_dep, libmatrix_headers_dep],
+        dependencies: [x11_dep, libmatrix_headers_dep, xrandr_dep],
         )
 
     native_x11_dep = declare_dependency(

--- a/src/wscript_build
+++ b/src/wscript_build
@@ -97,8 +97,8 @@ flavor_uselibs = {
   'wayland-glesv2' : ['wayland-client', 'wayland-egl', 'wayland-cursor', 'glad-egl-wayland', 'glad-glesv2', 'matrix-glesv2', 'common-glesv2'],
   'win32-gl': ['glad-gl', 'glad-wgl', 'matrix-gl', 'common-gl'],
   'win32-glesv2': ['glad-egl-win32', 'glad-glesv2', 'matrix-glesv2', 'common-glesv2'],
-  'x11-gl' : ['x11', 'glad-gl', 'glad-glx', 'matrix-gl', 'common-gl'],
-  'x11-glesv2' : ['x11', 'glad-egl-x11', 'glad-glesv2', 'matrix-glesv2', 'common-glesv2'],
+  'x11-gl' : ['x11', 'Xrandr', 'glad-gl', 'glad-glx', 'matrix-gl', 'common-gl'],
+  'x11-glesv2' : ['x11', 'Xrandr', 'glad-egl-x11', 'glad-glesv2', 'matrix-glesv2', 'common-glesv2'],
 }
 
 flavor_defines = {

--- a/wscript
+++ b/wscript
@@ -207,6 +207,7 @@ def configure_linux(ctx):
 
     # Check optional packages
     opt_pkgs = [('x11', 'x11', None, list_contains(ctx.options.flavors, 'x11')),
+                ('xrandr', 'Xrandr', None, list_contains(ctx.options.flavors, 'x11')),
                 ('libdrm','drm', None, list_contains(ctx.options.flavors, 'drm')),
                 ('gbm','gbm', None, list_contains(ctx.options.flavors, 'drm')),
                 ('libudev', 'udev', None, list_contains(ctx.options.flavors, 'drm')),


### PR DESCRIPTION
When running `glmark2 --fullscreen` on a multi-screen setup, the glmark2 surface size would be the total screen size, causing fullscreen display issues. 
For example, when two monitors are connected in extended mode with resolutions of 1920x1080 each, the surface size would be 3840x1080 fullscreen. This would result in the glmark2 window only partially displaying on the primary monitor, and not showing on the secondary monitor at all. 
This modification ensures that the fullscreen size is set to the primary monitor's resolution instead.