### PR TITLE
Add a missing include for std::copy

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -25,6 +25,7 @@
 #include "log.h"
 #include "gl-headers.h"
 
+#include <algorithm>
 
 Mesh::Mesh() :
     vertex_size_(0), interleave_(false), vbo_update_method_(VBOUpdateMethodMap),


### PR DESCRIPTION
This is to fix a build error when we use Clang modules build in Chromium.