### PR TITLE
drm: Fix surface size selection to respect resolution from -s option

### DIFF
--- a/src/canvas-generic.cpp
+++ b/src/canvas-generic.cpp
@@ -287,12 +287,14 @@ CanvasGeneric::resize_no_viewport(int width, int height)
                                              request_fullscreen, vid, mods);
     NativeState::WindowProperties cur_properties;
 
-    native_state_.window(cur_properties);
+    native_window_ = native_state_.window(cur_properties);
 
-    if ((cur_properties.fullscreen == properties.fullscreen &&
-         cur_properties.width > 0 && cur_properties.height > 0) ||
+    if (native_window_ && (
+        (cur_properties.fullscreen == properties.fullscreen &&
+            cur_properties.width > 0 &&
+            cur_properties.height > 0) ||
         (cur_properties.width == properties.width &&
-         cur_properties.height == properties.height))
+            cur_properties.height == properties.height)))
     {
         return true;
     }


### PR DESCRIPTION
[Problem]
The `glmark2-es2-drm` binary always used the maximum display resolution, ignoring the user-specified `-s <width>x<height>`. This caused benchmarks to run at fullscreen/highest resolution, distorting performance results.

[Solution]
Adjusted the DRM backend to select the closest supported mode based on the requested size. If no exact match exists, it picks the nearest available resolution by pixel area. Also updated `resize_no_viewport()` to recreate the window if resolution or fullscreen state doesn't match the request.

[Platform/device]
AMD Ryzen with Radeon Vega 8 Graphics (raven)
DRM 3.57, Mesa 23.2.1, Kernel 6.8.0-52-generic

[Test/verification]
Command: `glmark2-es2-drm -s 800x600 -b terrain`

- Before: Surface Size = 1920x1080 fullscreen, Score: 36 FPS
- After:  Surface Size = 800x600 fullscreen, Score: 102 FPS