### PR TITLE
github: Use windows-2022 runner for Windows builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
       run: DESTDIR=/tmp/glmark2-install ninja -C build install
 
   build-meson-win32-msvc:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v1
     - name: Setup Python

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,21 @@ jobs:
     - name: Install
       run: DESTDIR=/tmp/glmark2-install ninja -C build install
 
+  build-meson-only-gbm:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install meson libgbm-dev
+    - name: Setup
+      run: meson setup build -Dflavors=gbm-gl,gbm-glesv2
+    - name: Build
+      run: ninja -C build
+    - name: Install
+      run: DESTDIR=/tmp/glmark2-install ninja -C build install
+
   build-meson-only-wayland:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-meson:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
@@ -25,7 +25,7 @@ jobs:
       run: DESTDIR=/tmp/glmark2-install ninja -C build install
 
   build-meson-only-drm:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
@@ -40,7 +40,7 @@ jobs:
       run: DESTDIR=/tmp/glmark2-install ninja -C build install
 
   build-meson-only-wayland:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
@@ -55,7 +55,7 @@ jobs:
       run: DESTDIR=/tmp/glmark2-install ninja -C build install
 
   build-meson-only-x11:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
@@ -70,7 +70,7 @@ jobs:
       run: DESTDIR=/tmp/glmark2-install ninja -C build install
 
   build-meson-only-null:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
@@ -100,7 +100,7 @@ jobs:
       run: DESTDIR=/tmp/glmark2-install ninja -C build install
 
   build-meson-win32-mingw:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies


### PR DESCRIPTION
Support for the windows-2019 runner has been removed from github.