### PR TITLE
Fix GLSL bug: mat3 NormalMatrix should multiply vec3, not vec4 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,8 +228,24 @@ jobs:
         meson setup build -Dflavors=x11-gl --prefix=/opt/homebrew
     - name: Build
       run: ninja -C build
+    - name: Fix library paths for portability
+      run: |
+        # Copy required dynamic libraries to a local lib directory
+        mkdir -p /tmp/glmark2-install-libs
+        cp /opt/homebrew/opt/jpeg-turbo/lib/libjpeg.8.dylib /tmp/glmark2-install-libs/
+        cp /opt/homebrew/opt/libpng/lib/libpng16.16.dylib /tmp/glmark2-install-libs/
+        # Fix library paths in binary to use @executable_path
+        install_name_tool -change /opt/homebrew/opt/jpeg-turbo/lib/libjpeg.8.dylib @executable_path/../lib/libjpeg.8.dylib build/src/glmark2
+        install_name_tool -change /opt/homebrew/opt/libpng/lib/libpng16.16.dylib @executable_path/../lib/libpng16.16.dylib build/src/glmark2
+        # Fix library IDs and inter-dependencies
+        install_name_tool -id @executable_path/../lib/libjpeg.8.dylib /tmp/glmark2-install-libs/libjpeg.8.dylib
+        install_name_tool -id @executable_path/../lib/libpng16.16.dylib /tmp/glmark2-install-libs/libpng16.16.dylib
     - name: Install to staging directory
-      run: DESTDIR=/tmp/glmark2-install ninja -C build install
+      run: |
+        DESTDIR=/tmp/glmark2-install ninja -C build install
+        # Add bundled libraries
+        mkdir -p /tmp/glmark2-install/opt/homebrew/lib
+        cp /tmp/glmark2-install-libs/*.dylib /tmp/glmark2-install/opt/homebrew/lib/
     - name: Create artifact with proper structure
       run: |
         cd /tmp/glmark2-install
@@ -258,8 +274,24 @@ jobs:
         meson setup build -Dflavors=x11-gl --prefix=/usr/local
     - name: Build
       run: ninja -C build
+    - name: Fix library paths for portability
+      run: |
+        # Copy required dynamic libraries to a local lib directory
+        mkdir -p /tmp/glmark2-install-libs
+        cp /usr/local/opt/jpeg-turbo/lib/libjpeg.8.dylib /tmp/glmark2-install-libs/
+        cp /usr/local/opt/libpng/lib/libpng16.16.dylib /tmp/glmark2-install-libs/
+        # Fix library paths in binary to use @executable_path
+        install_name_tool -change /usr/local/opt/jpeg-turbo/lib/libjpeg.8.dylib @executable_path/../lib/libjpeg.8.dylib build/src/glmark2
+        install_name_tool -change /usr/local/opt/libpng/lib/libpng16.16.dylib @executable_path/../lib/libpng16.16.dylib build/src/glmark2
+        # Fix library IDs and inter-dependencies
+        install_name_tool -id @executable_path/../lib/libjpeg.8.dylib /tmp/glmark2-install-libs/libjpeg.8.dylib
+        install_name_tool -id @executable_path/../lib/libpng16.16.dylib /tmp/glmark2-install-libs/libpng16.16.dylib
     - name: Install to staging directory
-      run: DESTDIR=/tmp/glmark2-install ninja -C build install
+      run: |
+        DESTDIR=/tmp/glmark2-install ninja -C build install
+        # Add bundled libraries
+        mkdir -p /tmp/glmark2-install/usr/local/lib
+        cp /tmp/glmark2-install-libs/*.dylib /tmp/glmark2-install/usr/local/lib/
     - name: Create artifact with proper structure
       run: |
         cd /tmp/glmark2-install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,8 +239,8 @@ jobs:
         cp /opt/homebrew/opt/jpeg-turbo/lib/libjpeg.8.dylib /tmp/glmark2-install-libs/
         cp /opt/homebrew/opt/libpng/lib/libpng16.16.dylib /tmp/glmark2-install-libs/
         # Fix library paths in binary to use @executable_path
-        install_name_tool -change /opt/homebrew/opt/jpeg-turbo/lib/libjpeg.8.dylib @executable_path/../lib/libjpeg.8.dylib build/src/glmark2-x11-gl
-        install_name_tool -change /opt/homebrew/opt/libpng/lib/libpng16.16.dylib @executable_path/../lib/libpng16.16.dylib build/src/glmark2-x11-gl
+        install_name_tool -change /opt/homebrew/opt/jpeg-turbo/lib/libjpeg.8.dylib @executable_path/../lib/libjpeg.8.dylib build/src/glmark2
+        install_name_tool -change /opt/homebrew/opt/libpng/lib/libpng16.16.dylib @executable_path/../lib/libpng16.16.dylib build/src/glmark2
         # Fix library IDs and inter-dependencies
         install_name_tool -id @executable_path/../lib/libjpeg.8.dylib /tmp/glmark2-install-libs/libjpeg.8.dylib
         install_name_tool -id @executable_path/../lib/libpng16.16.dylib /tmp/glmark2-install-libs/libpng16.16.dylib
@@ -289,8 +289,8 @@ jobs:
         cp /usr/local/opt/jpeg-turbo/lib/libjpeg.8.dylib /tmp/glmark2-install-libs/
         cp /usr/local/opt/libpng/lib/libpng16.16.dylib /tmp/glmark2-install-libs/
         # Fix library paths in binary to use @executable_path
-        install_name_tool -change /usr/local/opt/jpeg-turbo/lib/libjpeg.8.dylib @executable_path/../lib/libjpeg.8.dylib build/src/glmark2-x11-gl
-        install_name_tool -change /usr/local/opt/libpng/lib/libpng16.16.dylib @executable_path/../lib/libpng16.16.dylib build/src/glmark2-x11-gl
+        install_name_tool -change /usr/local/opt/jpeg-turbo/lib/libjpeg.8.dylib @executable_path/../lib/libjpeg.8.dylib build/src/glmark2
+        install_name_tool -change /usr/local/opt/libpng/lib/libpng16.16.dylib @executable_path/../lib/libpng16.16.dylib build/src/glmark2
         # Fix library IDs and inter-dependencies
         install_name_tool -id @executable_path/../lib/libjpeg.8.dylib /tmp/glmark2-install-libs/libjpeg.8.dylib
         install_name_tool -id @executable_path/../lib/libpng16.16.dylib /tmp/glmark2-install-libs/libpng16.16.dylib

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,9 +232,9 @@ jobs:
       run: DESTDIR=/tmp/glmark2-install ninja -C build install
     - name: Create artifact with proper structure
       run: |
-        mkdir -p artifacts/macos-arm64
         cd /tmp/glmark2-install
         tar -czf /tmp/glmark2-macos-arm64.tar.gz .
+        mkdir -p artifacts/macos-arm64
         mv /tmp/glmark2-macos-arm64.tar.gz artifacts/macos-arm64/
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
@@ -262,9 +262,9 @@ jobs:
       run: DESTDIR=/tmp/glmark2-install ninja -C build install
     - name: Create artifact with proper structure
       run: |
-        mkdir -p artifacts/macos-x86_64
         cd /tmp/glmark2-install
         tar -czf /tmp/glmark2-macos-x86_64.tar.gz .
+        mkdir -p artifacts/macos-x86_64
         mv /tmp/glmark2-macos-x86_64.tar.gz artifacts/macos-x86_64/
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,6 +225,10 @@ jobs:
     - name: Setup
       run: |
         export PKG_CONFIG_PATH="/opt/homebrew/opt/jpeg-turbo/lib/pkgconfig:/opt/homebrew/opt/libpng/lib/pkgconfig:$PKG_CONFIG_PATH"
+        export MACOSX_DEPLOYMENT_TARGET=11.0
+        export CFLAGS="-mmacosx-version-min=11.0"
+        export CXXFLAGS="-mmacosx-version-min=11.0"
+        export LDFLAGS="-mmacosx-version-min=11.0"
         meson setup build -Dflavors=x11-gl --prefix=/opt/homebrew
     - name: Build
       run: ninja -C build
@@ -271,6 +275,10 @@ jobs:
     - name: Setup
       run: |
         export PKG_CONFIG_PATH="/usr/local/opt/jpeg-turbo/lib/pkgconfig:/usr/local/opt/libpng/lib/pkgconfig:$PKG_CONFIG_PATH"
+        export MACOSX_DEPLOYMENT_TARGET=10.13
+        export CFLAGS="-mmacosx-version-min=10.13"
+        export CXXFLAGS="-mmacosx-version-min=10.13"
+        export LDFLAGS="-mmacosx-version-min=10.13"
         meson setup build -Dflavors=x11-gl --prefix=/usr/local
     - name: Build
       run: ninja -C build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
     - master
+  workflow_dispatch:
 
 jobs:
   build-meson:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,10 +275,10 @@ jobs:
     - name: Setup
       run: |
         export PKG_CONFIG_PATH="/usr/local/opt/jpeg-turbo/lib/pkgconfig:/usr/local/opt/libpng/lib/pkgconfig:$PKG_CONFIG_PATH"
-        export MACOSX_DEPLOYMENT_TARGET=10.13
-        export CFLAGS="-mmacosx-version-min=10.13"
-        export CXXFLAGS="-mmacosx-version-min=10.13"
-        export LDFLAGS="-mmacosx-version-min=10.13"
+        export MACOSX_DEPLOYMENT_TARGET=10.15
+        export CFLAGS="-mmacosx-version-min=10.15"
+        export CXXFLAGS="-mmacosx-version-min=10.15"
+        export LDFLAGS="-mmacosx-version-min=10.15"
         meson setup build -Dflavors=x11-gl --prefix=/usr/local
     - name: Build
       run: ninja -C build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,7 @@ jobs:
         path: artifacts/windows-mingw/
 
   build-meson-win32-msvc:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v4
     - name: Setup Python

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -336,7 +336,29 @@ jobs:
           - **glmark2-macos-arm64** - macOS Apple Silicon (ARM64) build with XQuartz
           - **glmark2-macos-x86_64** - macOS Intel (x86_64) build with XQuartz
           
-          Each archive contains both `.tar.gz` and `.zip` formats for convenience.
+          #### macOS Installation
+          
+          **Prerequisites:** Install XQuartz first:
+          ```bash
+          brew install --cask xquartz
+          ```
+          
+          **Installation:**
+          ```bash
+          # macOS ARM64 (Apple Silicon)
+          sudo tar -xzf glmark2-macos-arm64.tar.gz -C /
+          sudo xattr -cr /opt/homebrew/bin/glmark2
+          
+          # macOS Intel (x86_64)
+          sudo tar -xzf glmark2-macos-x86_64.tar.gz -C /
+          sudo xattr -cr /usr/local/bin/glmark2
+          ```
+          
+          The `xattr -cr` command removes quarantine attributes that macOS applies to downloaded files.
+          
+          Then run with: `glmark2`
+          
+          Each Linux/Windows archive contains both `.tar.gz` and `.zip` formats for convenience.
           
           **Build Date:** $(date +"%Y-%m-%d %H:%M:%S UTC")
           **Commit:** ${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,9 +212,69 @@ jobs:
         name: glmark2-windows-msvc
         path: artifacts/windows-msvc/
 
+  build-meson-macos-arm64:
+    runs-on: macos-14
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        brew install meson ninja pkg-config jpeg-turbo libpng
+    - name: Install XQuartz
+      run: |
+        brew install --cask xquartz
+    - name: Setup
+      run: |
+        export PKG_CONFIG_PATH="/opt/homebrew/opt/jpeg-turbo/lib/pkgconfig:/opt/homebrew/opt/libpng/lib/pkgconfig:$PKG_CONFIG_PATH"
+        meson setup build -Dflavors=x11-gl
+    - name: Build
+      run: ninja -C build
+    - name: Install
+      run: DESTDIR=/tmp/glmark2-install ninja -C build install
+    - name: Create artifact directory
+      run: |
+        mkdir -p artifacts/macos-arm64
+        cp -r /tmp/glmark2-install/* artifacts/macos-arm64/
+        cp build/src/glmark2 artifacts/macos-arm64/
+        cp -r data artifacts/macos-arm64/
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: glmark2-macos-arm64
+        path: artifacts/macos-arm64/
+
+  build-meson-macos-x86_64:
+    runs-on: macos-13
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        brew install meson ninja pkg-config jpeg-turbo libpng
+    - name: Install XQuartz
+      run: |
+        brew install --cask xquartz
+    - name: Setup
+      run: |
+        export PKG_CONFIG_PATH="/usr/local/opt/jpeg-turbo/lib/pkgconfig:/usr/local/opt/libpng/lib/pkgconfig:$PKG_CONFIG_PATH"
+        meson setup build -Dflavors=x11-gl
+    - name: Build
+      run: ninja -C build
+    - name: Install
+      run: DESTDIR=/tmp/glmark2-install ninja -C build install
+    - name: Create artifact directory
+      run: |
+        mkdir -p artifacts/macos-x86_64
+        cp -r /tmp/glmark2-install/* artifacts/macos-x86_64/
+        cp build/src/glmark2 artifacts/macos-x86_64/
+        cp -r data artifacts/macos-x86_64/
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: glmark2-macos-x86_64
+        path: artifacts/macos-x86_64/
+
   release:
     if: github.event_name == 'workflow_dispatch'
-    needs: [build-meson, build-meson-only-drm, build-meson-only-wayland, build-meson-only-x11, build-meson-only-null, build-meson-only-dispmanx, build-meson-win32-mingw, build-meson-win32-msvc]
+    needs: [build-meson, build-meson-only-drm, build-meson-only-wayland, build-meson-only-x11, build-meson-only-null, build-meson-only-dispmanx, build-meson-win32-mingw, build-meson-win32-msvc, build-meson-macos-arm64, build-meson-macos-x86_64]
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
@@ -261,6 +321,10 @@ jobs:
           ### Windows Builds
           - **glmark2-windows-mingw** - Windows build using MinGW cross-compilation
           - **glmark2-windows-msvc** - Windows build using native MSVC
+          
+          ### macOS Builds
+          - **glmark2-macos-arm64** - macOS Apple Silicon (ARM64) build with XQuartz
+          - **glmark2-macos-x86_64** - macOS Intel (x86_64) build with XQuartz
           
           Each archive contains both `.tar.gz` and `.zip` formats for convenience.
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,16 @@ jobs:
       run: ninja -C build
     - name: Install
       run: DESTDIR=/tmp/glmark2-install ninja -C build install
+    - name: Create artifact directory
+      run: |
+        mkdir -p artifacts/linux-all-flavors
+        cp -r /tmp/glmark2-install/* artifacts/linux-all-flavors/
+        cp build/src/glmark2-* artifacts/linux-all-flavors/ 2>/dev/null || true
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: glmark2-linux-all-flavors
+        path: artifacts/linux-all-flavors/
 
   build-meson-only-drm:
     runs-on: ubuntu-20.04
@@ -38,6 +48,16 @@ jobs:
       run: ninja -C build
     - name: Install
       run: DESTDIR=/tmp/glmark2-install ninja -C build install
+    - name: Create artifact directory
+      run: |
+        mkdir -p artifacts/linux-drm-only
+        cp -r /tmp/glmark2-install/* artifacts/linux-drm-only/
+        cp build/src/glmark2-* artifacts/linux-drm-only/ 2>/dev/null || true
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: glmark2-linux-drm-only
+        path: artifacts/linux-drm-only/
 
   build-meson-only-wayland:
     runs-on: ubuntu-20.04
@@ -53,6 +73,16 @@ jobs:
       run: ninja -C build
     - name: Install
       run: DESTDIR=/tmp/glmark2-install ninja -C build install
+    - name: Create artifact directory
+      run: |
+        mkdir -p artifacts/linux-wayland-only
+        cp -r /tmp/glmark2-install/* artifacts/linux-wayland-only/
+        cp build/src/glmark2-* artifacts/linux-wayland-only/ 2>/dev/null || true
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: glmark2-linux-wayland-only
+        path: artifacts/linux-wayland-only/
 
   build-meson-only-x11:
     runs-on: ubuntu-20.04
@@ -68,6 +98,16 @@ jobs:
       run: ninja -C build
     - name: Install
       run: DESTDIR=/tmp/glmark2-install ninja -C build install
+    - name: Create artifact directory
+      run: |
+        mkdir -p artifacts/linux-x11-only
+        cp -r /tmp/glmark2-install/* artifacts/linux-x11-only/
+        cp build/src/glmark2-* artifacts/linux-x11-only/ 2>/dev/null || true
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: glmark2-linux-x11-only
+        path: artifacts/linux-x11-only/
 
   build-meson-only-null:
     runs-on: ubuntu-20.04
@@ -83,6 +123,16 @@ jobs:
       run: ninja -C build
     - name: Install
       run: DESTDIR=/tmp/glmark2-install ninja -C build install
+    - name: Create artifact directory
+      run: |
+        mkdir -p artifacts/linux-null-only
+        cp -r /tmp/glmark2-install/* artifacts/linux-null-only/
+        cp build/src/glmark2-* artifacts/linux-null-only/ 2>/dev/null || true
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: glmark2-linux-null-only
+        path: artifacts/linux-null-only/
 
   build-meson-only-dispmanx:
     runs-on: ubuntu-22.04-arm
@@ -98,6 +148,16 @@ jobs:
       run: ninja -C build
     - name: Install
       run: DESTDIR=/tmp/glmark2-install ninja -C build install
+    - name: Create artifact directory
+      run: |
+        mkdir -p artifacts/linux-dispmanx-only
+        cp -r /tmp/glmark2-install/* artifacts/linux-dispmanx-only/
+        cp build/src/glmark2-* artifacts/linux-dispmanx-only/ 2>/dev/null || true
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: glmark2-linux-dispmanx-only
+        path: artifacts/linux-dispmanx-only/
 
   build-meson-win32-mingw:
     runs-on: ubuntu-20.04
@@ -113,6 +173,16 @@ jobs:
       run: ninja -C build
     - name: Install
       run: DESTDIR=/tmp/glmark2-install ninja -C build install
+    - name: Create artifact directory
+      run: |
+        mkdir -p artifacts/windows-mingw
+        cp -r /tmp/glmark2-install/* artifacts/windows-mingw/
+        cp build/src/glmark2*.exe artifacts/windows-mingw/ 2>/dev/null || true
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: glmark2-windows-mingw
+        path: artifacts/windows-mingw/
 
   build-meson-win32-msvc:
     runs-on: windows-2019
@@ -128,3 +198,15 @@ jobs:
       run: meson setup --vsenv build -Dflavors='win32-gl,win32-glesv2'
     - name: Build
       run: meson compile -C build
+    - name: Install
+      run: meson install -C build --destdir ../glmark2-install
+    - name: Create artifact directory
+      run: |
+        mkdir artifacts\windows-msvc
+        xcopy glmark2-install\* artifacts\windows-msvc\ /E /I
+        copy build\src\glmark2*.exe artifacts\windows-msvc\ 2>nul || echo "No exe files found in build directory"
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: glmark2-windows-msvc
+        path: artifacts/windows-msvc/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,3 +211,63 @@ jobs:
       with:
         name: glmark2-windows-msvc
         path: artifacts/windows-msvc/
+
+  release:
+    if: github.event_name == 'workflow_dispatch'
+    needs: [build-meson, build-meson-only-drm, build-meson-only-wayland, build-meson-only-x11, build-meson-only-null, build-meson-only-dispmanx, build-meson-win32-mingw, build-meson-win32-msvc]
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: release-artifacts
+    - name: Create release archives
+      run: |
+        cd release-artifacts
+        for dir in */; do
+          if [ -d "$dir" ]; then
+            echo "Creating archive for $dir"
+            tar -czf "${dir%/}.tar.gz" -C "$dir" .
+            zip -r "${dir%/}.zip" "$dir"
+          fi
+        done
+        ls -la *.tar.gz *.zip
+    - name: Generate release tag
+      id: tag
+      run: |
+        TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
+        TAG="release-${TIMESTAMP}"
+        echo "tag=${TAG}" >> $GITHUB_OUTPUT
+        echo "Generated tag: ${TAG}"
+    - name: Create Release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ steps.tag.outputs.tag }}
+        name: "GLMark2 Release ${{ steps.tag.outputs.tag }}"
+        body: |
+          ## GLMark2 Build Artifacts
+          
+          This release contains pre-built GLMark2 binaries for multiple platforms and configurations:
+          
+          ### Linux Builds
+          - **glmark2-linux-all-flavors** - Complete build with all display backends (X11, Wayland, DRM, null)
+          - **glmark2-linux-drm-only** - DRM-only build for direct rendering
+          - **glmark2-linux-wayland-only** - Wayland-only build
+          - **glmark2-linux-x11-only** - X11-only build
+          - **glmark2-linux-null-only** - Headless/null build for benchmarking without display
+          - **glmark2-linux-dispmanx-only** - Raspberry Pi DispmanX build
+          
+          ### Windows Builds
+          - **glmark2-windows-mingw** - Windows build using MinGW cross-compilation
+          - **glmark2-windows-msvc** - Windows build using native MSVC
+          
+          Each archive contains both `.tar.gz` and `.zip` formats for convenience.
+          
+          **Build Date:** $(date +"%Y-%m-%d %H:%M:%S UTC")
+          **Commit:** ${{ github.sha }}
+        draft: false
+        prerelease: false
+        files: |
+          release-artifacts/*.tar.gz
+          release-artifacts/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,9 +233,9 @@ jobs:
     - name: Create artifact with proper structure
       run: |
         cd /tmp/glmark2-install
-        tar -czf /tmp/glmark2-macos-arm64.tar.gz .
-        mkdir -p artifacts/macos-arm64
-        mv /tmp/glmark2-macos-arm64.tar.gz artifacts/macos-arm64/
+        tar -czf glmark2-macos-arm64.tar.gz .
+        mkdir -p $GITHUB_WORKSPACE/artifacts/macos-arm64
+        mv glmark2-macos-arm64.tar.gz $GITHUB_WORKSPACE/artifacts/macos-arm64/
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -263,9 +263,9 @@ jobs:
     - name: Create artifact with proper structure
       run: |
         cd /tmp/glmark2-install
-        tar -czf /tmp/glmark2-macos-x86_64.tar.gz .
-        mkdir -p artifacts/macos-x86_64
-        mv /tmp/glmark2-macos-x86_64.tar.gz artifacts/macos-x86_64/
+        tar -czf glmark2-macos-x86_64.tar.gz .
+        mkdir -p $GITHUB_WORKSPACE/artifacts/macos-x86_64
+        mv glmark2-macos-x86_64.tar.gz $GITHUB_WORKSPACE/artifacts/macos-x86_64/
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -347,11 +347,11 @@ jobs:
           ```bash
           # macOS ARM64 (Apple Silicon)
           sudo tar -xzf glmark2-macos-arm64.tar.gz -C /
-          sudo xattr -cr /opt/homebrew/bin/glmark2
+          sudo /usr/bin/xattr -cr /opt/homebrew/bin/glmark2
           
           # macOS Intel (x86_64)
           sudo tar -xzf glmark2-macos-x86_64.tar.gz -C /
-          sudo xattr -cr /usr/local/bin/glmark2
+          sudo /usr/bin/xattr -cr /usr/local/bin/glmark2
           ```
           
           The `xattr -cr` command removes quarantine attributes that macOS applies to downloaded files.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,7 +213,7 @@ jobs:
         path: artifacts/windows-msvc/
 
   build-meson-macos-arm64:
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies
@@ -225,25 +225,25 @@ jobs:
     - name: Setup
       run: |
         export PKG_CONFIG_PATH="/opt/homebrew/opt/jpeg-turbo/lib/pkgconfig:/opt/homebrew/opt/libpng/lib/pkgconfig:$PKG_CONFIG_PATH"
-        meson setup build -Dflavors=x11-gl
+        meson setup build -Dflavors=x11-gl --prefix=/opt/homebrew
     - name: Build
       run: ninja -C build
-    - name: Install
+    - name: Install to staging directory
       run: DESTDIR=/tmp/glmark2-install ninja -C build install
-    - name: Create artifact directory
+    - name: Create artifact with proper structure
       run: |
         mkdir -p artifacts/macos-arm64
-        cp -r /tmp/glmark2-install/* artifacts/macos-arm64/
-        cp build/src/glmark2 artifacts/macos-arm64/
-        cp -r data artifacts/macos-arm64/
+        cd /tmp/glmark2-install
+        tar -czf /tmp/glmark2-macos-arm64.tar.gz .
+        mv /tmp/glmark2-macos-arm64.tar.gz artifacts/macos-arm64/
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
         name: glmark2-macos-arm64
-        path: artifacts/macos-arm64/
+        path: artifacts/macos-arm64/glmark2-macos-arm64.tar.gz
 
   build-meson-macos-x86_64:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies
@@ -255,22 +255,22 @@ jobs:
     - name: Setup
       run: |
         export PKG_CONFIG_PATH="/usr/local/opt/jpeg-turbo/lib/pkgconfig:/usr/local/opt/libpng/lib/pkgconfig:$PKG_CONFIG_PATH"
-        meson setup build -Dflavors=x11-gl
+        meson setup build -Dflavors=x11-gl --prefix=/usr/local
     - name: Build
       run: ninja -C build
-    - name: Install
+    - name: Install to staging directory
       run: DESTDIR=/tmp/glmark2-install ninja -C build install
-    - name: Create artifact directory
+    - name: Create artifact with proper structure
       run: |
         mkdir -p artifacts/macos-x86_64
-        cp -r /tmp/glmark2-install/* artifacts/macos-x86_64/
-        cp build/src/glmark2 artifacts/macos-x86_64/
-        cp -r data artifacts/macos-x86_64/
+        cd /tmp/glmark2-install
+        tar -czf /tmp/glmark2-macos-x86_64.tar.gz .
+        mv /tmp/glmark2-macos-x86_64.tar.gz artifacts/macos-x86_64/
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
         name: glmark2-macos-x86_64
-        path: artifacts/macos-x86_64/
+        path: artifacts/macos-x86_64/glmark2-macos-x86_64.tar.gz
 
   release:
     if: github.event_name == 'workflow_dispatch'
@@ -285,14 +285,24 @@ jobs:
     - name: Create release archives
       run: |
         cd release-artifacts
+        # macOS archives are already tarballs, just copy them
+        find . -name "*.tar.gz" -exec mv {} . \;
+        # Create archives for other platforms
         for dir in */; do
           if [ -d "$dir" ]; then
-            echo "Creating archive for $dir"
-            tar -czf "${dir%/}.tar.gz" -C "$dir" .
-            zip -r "${dir%/}.zip" "$dir"
+            case "$dir" in
+              glmark2-macos-*)
+                echo "Skipping $dir - already archived"
+                ;;
+              *)
+                echo "Creating archive for $dir"
+                tar -czf "${dir%/}.tar.gz" -C "$dir" .
+                zip -r "${dir%/}.zip" "$dir"
+                ;;
+            esac
           fi
         done
-        ls -la *.tar.gz *.zip
+        ls -la *.tar.gz *.zip 2>/dev/null || true
     - name: Generate release tag
       id: tag
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,8 +239,8 @@ jobs:
         cp /opt/homebrew/opt/jpeg-turbo/lib/libjpeg.8.dylib /tmp/glmark2-install-libs/
         cp /opt/homebrew/opt/libpng/lib/libpng16.16.dylib /tmp/glmark2-install-libs/
         # Fix library paths in binary to use @executable_path
-        install_name_tool -change /opt/homebrew/opt/jpeg-turbo/lib/libjpeg.8.dylib @executable_path/../lib/libjpeg.8.dylib build/src/glmark2
-        install_name_tool -change /opt/homebrew/opt/libpng/lib/libpng16.16.dylib @executable_path/../lib/libpng16.16.dylib build/src/glmark2
+        install_name_tool -change /opt/homebrew/opt/jpeg-turbo/lib/libjpeg.8.dylib @executable_path/../lib/libjpeg.8.dylib build/src/glmark2-x11-gl
+        install_name_tool -change /opt/homebrew/opt/libpng/lib/libpng16.16.dylib @executable_path/../lib/libpng16.16.dylib build/src/glmark2-x11-gl
         # Fix library IDs and inter-dependencies
         install_name_tool -id @executable_path/../lib/libjpeg.8.dylib /tmp/glmark2-install-libs/libjpeg.8.dylib
         install_name_tool -id @executable_path/../lib/libpng16.16.dylib /tmp/glmark2-install-libs/libpng16.16.dylib
@@ -289,8 +289,8 @@ jobs:
         cp /usr/local/opt/jpeg-turbo/lib/libjpeg.8.dylib /tmp/glmark2-install-libs/
         cp /usr/local/opt/libpng/lib/libpng16.16.dylib /tmp/glmark2-install-libs/
         # Fix library paths in binary to use @executable_path
-        install_name_tool -change /usr/local/opt/jpeg-turbo/lib/libjpeg.8.dylib @executable_path/../lib/libjpeg.8.dylib build/src/glmark2
-        install_name_tool -change /usr/local/opt/libpng/lib/libpng16.16.dylib @executable_path/../lib/libpng16.16.dylib build/src/glmark2
+        install_name_tool -change /usr/local/opt/jpeg-turbo/lib/libjpeg.8.dylib @executable_path/../lib/libjpeg.8.dylib build/src/glmark2-x11-gl
+        install_name_tool -change /usr/local/opt/libpng/lib/libpng16.16.dylib @executable_path/../lib/libpng16.16.dylib build/src/glmark2-x11-gl
         # Fix library IDs and inter-dependencies
         install_name_tool -id @executable_path/../lib/libjpeg.8.dylib /tmp/glmark2-install-libs/libjpeg.8.dylib
         install_name_tool -id @executable_path/../lib/libpng16.16.dylib /tmp/glmark2-install-libs/libpng16.16.dylib

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-meson:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies
@@ -36,7 +36,7 @@ jobs:
         path: artifacts/linux-all-flavors/
 
   build-meson-only-drm:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies
@@ -61,7 +61,7 @@ jobs:
         path: artifacts/linux-drm-only/
 
   build-meson-only-wayland:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies
@@ -86,7 +86,7 @@ jobs:
         path: artifacts/linux-wayland-only/
 
   build-meson-only-x11:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies
@@ -111,7 +111,7 @@ jobs:
         path: artifacts/linux-x11-only/
 
   build-meson-only-null:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies
@@ -161,7 +161,7 @@ jobs:
         path: artifacts/linux-dispmanx-only/
 
   build-meson-win32-mingw:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   build-meson:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -30,7 +30,7 @@ jobs:
         cp -r /tmp/glmark2-install/* artifacts/linux-all-flavors/
         cp build/src/glmark2-* artifacts/linux-all-flavors/ 2>/dev/null || true
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: glmark2-linux-all-flavors
         path: artifacts/linux-all-flavors/
@@ -38,7 +38,7 @@ jobs:
   build-meson-only-drm:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -55,7 +55,7 @@ jobs:
         cp -r /tmp/glmark2-install/* artifacts/linux-drm-only/
         cp build/src/glmark2-* artifacts/linux-drm-only/ 2>/dev/null || true
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: glmark2-linux-drm-only
         path: artifacts/linux-drm-only/
@@ -63,7 +63,7 @@ jobs:
   build-meson-only-wayland:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -80,7 +80,7 @@ jobs:
         cp -r /tmp/glmark2-install/* artifacts/linux-wayland-only/
         cp build/src/glmark2-* artifacts/linux-wayland-only/ 2>/dev/null || true
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: glmark2-linux-wayland-only
         path: artifacts/linux-wayland-only/
@@ -88,7 +88,7 @@ jobs:
   build-meson-only-x11:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -105,7 +105,7 @@ jobs:
         cp -r /tmp/glmark2-install/* artifacts/linux-x11-only/
         cp build/src/glmark2-* artifacts/linux-x11-only/ 2>/dev/null || true
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: glmark2-linux-x11-only
         path: artifacts/linux-x11-only/
@@ -113,7 +113,7 @@ jobs:
   build-meson-only-null:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -130,7 +130,7 @@ jobs:
         cp -r /tmp/glmark2-install/* artifacts/linux-null-only/
         cp build/src/glmark2-* artifacts/linux-null-only/ 2>/dev/null || true
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: glmark2-linux-null-only
         path: artifacts/linux-null-only/
@@ -138,7 +138,7 @@ jobs:
   build-meson-only-dispmanx:
     runs-on: ubuntu-22.04-arm
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -155,7 +155,7 @@ jobs:
         cp -r /tmp/glmark2-install/* artifacts/linux-dispmanx-only/
         cp build/src/glmark2-* artifacts/linux-dispmanx-only/ 2>/dev/null || true
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: glmark2-linux-dispmanx-only
         path: artifacts/linux-dispmanx-only/
@@ -163,7 +163,7 @@ jobs:
   build-meson-win32-mingw:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -180,7 +180,7 @@ jobs:
         cp -r /tmp/glmark2-install/* artifacts/windows-mingw/
         cp build/src/glmark2*.exe artifacts/windows-mingw/ 2>/dev/null || true
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: glmark2-windows-mingw
         path: artifacts/windows-mingw/
@@ -188,9 +188,9 @@ jobs:
   build-meson-win32-msvc:
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install meson
@@ -207,7 +207,7 @@ jobs:
         xcopy glmark2-install\* artifacts\windows-msvc\ /E /I
         copy build\src\glmark2*.exe artifacts\windows-msvc\ 2>nul || echo "No exe files found in build directory"
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: glmark2-windows-msvc
         path: artifacts/windows-msvc/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .lock-waf*
 waflib/**/*.pyc
 build/
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "climits": "cpp"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "climits": "cpp"
-    }
-}

--- a/data/shaders/bump-height.vert
+++ b/data/shaders/bump-height.vert
@@ -19,9 +19,9 @@ void main(void)
     // all of them perpendicular to the Normal. That is why we use
     // NormalMatrix, instead of ModelView, to transform the tangent and
     // bitangent.
-    NormalEye = normalize(NormalMatrix * normal);
-    TangentEye = normalize(NormalMatrix * tangent);
-    BitangentEye = normalize(NormalMatrix * cross(normal, tangent));
+    NormalEye = normalize(mat3(NormalMatrix) * normal);
+    TangentEye = normalize(mat3(NormalMatrix) * tangent);
+    BitangentEye = normalize(mat3(NormalMatrix) * cross(normal, tangent));
 
     // Transform the position to clip coordinates
     gl_Position = ModelViewProjectionMatrix * vec4(position, 1.0);

--- a/data/shaders/bump-height.vert
+++ b/data/shaders/bump-height.vert
@@ -19,9 +19,9 @@ void main(void)
     // all of them perpendicular to the Normal. That is why we use
     // NormalMatrix, instead of ModelView, to transform the tangent and
     // bitangent.
-    NormalEye = normalize(vec3(NormalMatrix) * normal);
-    TangentEye = normalize(vec3(NormalMatrix) * tangent);
-    BitangentEye = normalize(vec3(NormalMatrix) * cross(normal, tangent));
+    NormalEye = normalize(NormalMatrix * normal);
+    TangentEye = normalize(NormalMatrix * tangent);
+    BitangentEye = normalize(NormalMatrix * cross(normal, tangent));
 
     // Transform the position to clip coordinates
     gl_Position = ModelViewProjectionMatrix * vec4(position, 1.0);

--- a/data/shaders/bump-height.vert
+++ b/data/shaders/bump-height.vert
@@ -19,9 +19,9 @@ void main(void)
     // all of them perpendicular to the Normal. That is why we use
     // NormalMatrix, instead of ModelView, to transform the tangent and
     // bitangent.
-    NormalEye = normalize(vec3(NormalMatrix * vec4(normal, 1.0)));
-    TangentEye = normalize(vec3(NormalMatrix * vec4(tangent, 1.0)));
-    BitangentEye = normalize(vec3(NormalMatrix * vec4(cross(normal, tangent), 1.0)));
+    NormalEye = normalize(vec3(NormalMatrix) * normal);
+    TangentEye = normalize(vec3(NormalMatrix) * tangent);
+    BitangentEye = normalize(vec3(NormalMatrix) * cross(normal, tangent));
 
     // Transform the position to clip coordinates
     gl_Position = ModelViewProjectionMatrix * vec4(position, 1.0);

--- a/data/shaders/bump-normals.frag
+++ b/data/shaders/bump-normals.frag
@@ -21,7 +21,7 @@ void main(void)
     // Convert the normal to eye coordinates. Note that the normal map
     // we are using is using object coordinates (not tangent!) for the
     // normals, so we can multiply by the NormalMatrix as usual.
-    vec3 N = normalize(vec3(NormalMatrix * vec4(normal_scaled, 1.0)));
+    vec3 N = normalize(vec3(NormalMatrix) * normal_scaled);
 
     // In the lighting model we are using here (Blinn-Phong with light at
     // infinity, viewer at infinity), the light position/direction and the

--- a/data/shaders/bump-normals.frag
+++ b/data/shaders/bump-normals.frag
@@ -21,7 +21,7 @@ void main(void)
     // Convert the normal to eye coordinates. Note that the normal map
     // we are using is using object coordinates (not tangent!) for the
     // normals, so we can multiply by the NormalMatrix as usual.
-    vec3 N = normalize(NormalMatrix * normal_scaled);
+    vec3 N = normalize(mat3(NormalMatrix) * normal_scaled);
 
     // In the lighting model we are using here (Blinn-Phong with light at
     // infinity, viewer at infinity), the light position/direction and the

--- a/data/shaders/bump-normals.frag
+++ b/data/shaders/bump-normals.frag
@@ -21,7 +21,7 @@ void main(void)
     // Convert the normal to eye coordinates. Note that the normal map
     // we are using is using object coordinates (not tangent!) for the
     // normals, so we can multiply by the NormalMatrix as usual.
-    vec3 N = normalize(vec3(NormalMatrix) * normal_scaled);
+    vec3 N = normalize(NormalMatrix * normal_scaled);
 
     // In the lighting model we are using here (Blinn-Phong with light at
     // infinity, viewer at infinity), the light position/direction and the

--- a/data/shaders/bump-poly.vert
+++ b/data/shaders/bump-poly.vert
@@ -9,7 +9,7 @@ varying vec3 Normal;
 void main(void)
 {
     // Transform the normal to eye coordinates
-    Normal = normalize(NormalMatrix * normal);
+    Normal = normalize(mat3(NormalMatrix) * normal);
 
     // Transform the position to clip coordinates
     gl_Position = ModelViewProjectionMatrix * vec4(position, 1.0);

--- a/data/shaders/bump-poly.vert
+++ b/data/shaders/bump-poly.vert
@@ -9,7 +9,7 @@ varying vec3 Normal;
 void main(void)
 {
     // Transform the normal to eye coordinates
-    Normal = normalize(vec3(NormalMatrix) * normal);
+    Normal = normalize(NormalMatrix * normal);
 
     // Transform the position to clip coordinates
     gl_Position = ModelViewProjectionMatrix * vec4(position, 1.0);

--- a/data/shaders/bump-poly.vert
+++ b/data/shaders/bump-poly.vert
@@ -9,7 +9,7 @@ varying vec3 Normal;
 void main(void)
 {
     // Transform the normal to eye coordinates
-    Normal = normalize(vec3(NormalMatrix * vec4(normal, 1.0)));
+    Normal = normalize(vec3(NormalMatrix) * normal);
 
     // Transform the position to clip coordinates
     gl_Position = ModelViewProjectionMatrix * vec4(position, 1.0);

--- a/data/shaders/light-advanced.vert
+++ b/data/shaders/light-advanced.vert
@@ -9,7 +9,7 @@ varying vec3 Normal;
 void main(void)
 {
     // Transform the normal to eye coordinates
-    Normal = normalize(NormalMatrix * normal);
+    Normal = normalize(mat3(NormalMatrix) * normal);
 
     // Transform the position to clip coordinates
     gl_Position = ModelViewProjectionMatrix * vec4(position, 1.0);

--- a/data/shaders/light-advanced.vert
+++ b/data/shaders/light-advanced.vert
@@ -9,7 +9,7 @@ varying vec3 Normal;
 void main(void)
 {
     // Transform the normal to eye coordinates
-    Normal = normalize(vec3(NormalMatrix) * normal);
+    Normal = normalize(NormalMatrix * normal);
 
     // Transform the position to clip coordinates
     gl_Position = ModelViewProjectionMatrix * vec4(position, 1.0);

--- a/data/shaders/light-advanced.vert
+++ b/data/shaders/light-advanced.vert
@@ -9,7 +9,7 @@ varying vec3 Normal;
 void main(void)
 {
     // Transform the normal to eye coordinates
-    Normal = normalize(vec3(NormalMatrix * vec4(normal, 1.0)));
+    Normal = normalize(vec3(NormalMatrix) * normal);
 
     // Transform the position to clip coordinates
     gl_Position = ModelViewProjectionMatrix * vec4(position, 1.0);

--- a/data/shaders/light-basic-texgen.vert
+++ b/data/shaders/light-basic-texgen.vert
@@ -11,7 +11,7 @@ varying vec2 TextureCoord;
 void main(void)
 {
     // Transform the normal to eye coordinates
-    vec3 N = normalize(vec3(NormalMatrix * vec4(normal, 1.0)));
+    vec3 N = normalize(vec3(NormalMatrix) * normal);
 
     // The LightSourcePosition is actually its direction for directional light
     vec3 L = normalize(LightSourcePosition.xyz);

--- a/data/shaders/light-basic-texgen.vert
+++ b/data/shaders/light-basic-texgen.vert
@@ -11,7 +11,7 @@ varying vec2 TextureCoord;
 void main(void)
 {
     // Transform the normal to eye coordinates
-    vec3 N = normalize(NormalMatrix * normal);
+    vec3 N = normalize(mat3(NormalMatrix) * normal);
 
     // The LightSourcePosition is actually its direction for directional light
     vec3 L = normalize(LightSourcePosition.xyz);

--- a/data/shaders/light-basic-texgen.vert
+++ b/data/shaders/light-basic-texgen.vert
@@ -11,7 +11,7 @@ varying vec2 TextureCoord;
 void main(void)
 {
     // Transform the normal to eye coordinates
-    vec3 N = normalize(vec3(NormalMatrix) * normal);
+    vec3 N = normalize(NormalMatrix * normal);
 
     // The LightSourcePosition is actually its direction for directional light
     vec3 L = normalize(LightSourcePosition.xyz);

--- a/data/shaders/light-basic.vert
+++ b/data/shaders/light-basic.vert
@@ -11,7 +11,7 @@ varying vec2 TextureCoord;
 void main(void)
 {
     // Transform the normal to eye coordinates
-    vec3 N = normalize(vec3(NormalMatrix * vec4(normal, 1.0)));
+    vec3 N = normalize(vec3(NormalMatrix) * normal);
 
     // The LightSourcePosition is actually its direction for directional light
     vec3 L = normalize(LightSourcePosition.xyz);

--- a/data/shaders/light-basic.vert
+++ b/data/shaders/light-basic.vert
@@ -11,7 +11,7 @@ varying vec2 TextureCoord;
 void main(void)
 {
     // Transform the normal to eye coordinates
-    vec3 N = normalize(NormalMatrix * normal);
+    vec3 N = normalize(mat3(NormalMatrix) * normal);
 
     // The LightSourcePosition is actually its direction for directional light
     vec3 L = normalize(LightSourcePosition.xyz);

--- a/data/shaders/light-basic.vert
+++ b/data/shaders/light-basic.vert
@@ -11,7 +11,7 @@ varying vec2 TextureCoord;
 void main(void)
 {
     // Transform the normal to eye coordinates
-    vec3 N = normalize(vec3(NormalMatrix) * normal);
+    vec3 N = normalize(NormalMatrix * normal);
 
     // The LightSourcePosition is actually its direction for directional light
     vec3 L = normalize(LightSourcePosition.xyz);

--- a/data/shaders/light-phong.vert
+++ b/data/shaders/light-phong.vert
@@ -13,7 +13,7 @@ void main(void)
     vec4 current_position = vec4(position, 1.0);
 
     // Transform the normal to eye coordinates
-    vertex_normal = normalize(NormalMatrix * normal);
+    vertex_normal = normalize(mat3(NormalMatrix) * normal);
 
     // Transform the current position to eye coordinates
     vertex_position = ModelViewMatrix * current_position;

--- a/data/shaders/light-phong.vert
+++ b/data/shaders/light-phong.vert
@@ -13,7 +13,7 @@ void main(void)
     vec4 current_position = vec4(position, 1.0);
 
     // Transform the normal to eye coordinates
-    vertex_normal = normalize(vec3(NormalMatrix * vec4(normal, 1.0)));
+    vertex_normal = normalize(vec3(NormalMatrix) * normal);
 
     // Transform the current position to eye coordinates
     vertex_position = ModelViewMatrix * current_position;

--- a/data/shaders/light-phong.vert
+++ b/data/shaders/light-phong.vert
@@ -13,7 +13,7 @@ void main(void)
     vec4 current_position = vec4(position, 1.0);
 
     // Transform the normal to eye coordinates
-    vertex_normal = normalize(vec3(NormalMatrix) * normal);
+    vertex_normal = normalize(NormalMatrix * normal);
 
     // Transform the current position to eye coordinates
     vertex_position = ModelViewMatrix * current_position;

--- a/data/shaders/light-refract.vert
+++ b/data/shaders/light-refract.vert
@@ -15,7 +15,7 @@ void main(void)
     vec4 current_position = vec4(position, 1.0);
 
     // Transform the normal to eye coordinates
-    vertex_normal = normalize(vec3(NormalMatrix) * normal);
+    vertex_normal = normalize(NormalMatrix * normal);
 
     // Transform the current position to eye coordinates
     vertex_position = ModelViewMatrix * current_position;

--- a/data/shaders/light-refract.vert
+++ b/data/shaders/light-refract.vert
@@ -15,7 +15,7 @@ void main(void)
     vec4 current_position = vec4(position, 1.0);
 
     // Transform the normal to eye coordinates
-    vertex_normal = normalize(vec3(NormalMatrix * vec4(normal, 1.0)));
+    vertex_normal = normalize(vec3(NormalMatrix) * normal);
 
     // Transform the current position to eye coordinates
     vertex_position = ModelViewMatrix * current_position;

--- a/data/shaders/light-refract.vert
+++ b/data/shaders/light-refract.vert
@@ -15,7 +15,7 @@ void main(void)
     vec4 current_position = vec4(position, 1.0);
 
     // Transform the normal to eye coordinates
-    vertex_normal = normalize(NormalMatrix * normal);
+    vertex_normal = normalize(mat3(NormalMatrix) * normal);
 
     // Transform the current position to eye coordinates
     vertex_position = ModelViewMatrix * current_position;

--- a/data/shaders/pulsar-light.vert
+++ b/data/shaders/pulsar-light.vert
@@ -12,7 +12,7 @@ varying vec2 TextureCoord;
 void main(void)
 {
     // Transform the normal to eye coordinates
-    vec3 N = normalize(NormalMatrix * normal);
+    vec3 N = normalize(mat3(NormalMatrix) * normal);
 
     // The LightSourcePosition is actually its direction for directional light
     vec3 L = normalize(LightSourcePosition.xyz);

--- a/data/shaders/pulsar-light.vert
+++ b/data/shaders/pulsar-light.vert
@@ -12,7 +12,7 @@ varying vec2 TextureCoord;
 void main(void)
 {
     // Transform the normal to eye coordinates
-    vec3 N = normalize(vec3(NormalMatrix) * normal);
+    vec3 N = normalize(NormalMatrix * normal);
 
     // The LightSourcePosition is actually its direction for directional light
     vec3 L = normalize(LightSourcePosition.xyz);

--- a/data/shaders/pulsar-light.vert
+++ b/data/shaders/pulsar-light.vert
@@ -12,7 +12,7 @@ varying vec2 TextureCoord;
 void main(void)
 {
     // Transform the normal to eye coordinates
-    vec3 N = normalize(vec3(NormalMatrix * vec4(normal, 1.0)));
+    vec3 N = normalize(vec3(NormalMatrix) * normal);
 
     // The LightSourcePosition is actually its direction for directional light
     vec3 L = normalize(LightSourcePosition.xyz);

--- a/data/shaders/terrain.vert
+++ b/data/shaders/terrain.vert
@@ -26,10 +26,10 @@ void main()
 {
     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
     vViewPosition = -mvPosition.xyz;
-    vNormal = normalize(normalMatrix * normal);
+    vNormal = normalize(mat3(normalMatrix) * normal);
 
     // tangent and binormal vectors
-    vTangent = normalize(normalMatrix * tangent);
+    vTangent = normalize(mat3(normalMatrix) * tangent);
     vBinormal = cross( vNormal, vTangent );
     vBinormal = normalize( vBinormal );
 
@@ -43,5 +43,5 @@ void main()
     gl_Position = projectionMatrix * displacedPosition;
 
     vec3 normalTex = texture2D(tNormal, uv).xyz * 2.0 - 1.0;
-    vNormal = normalMatrix * normalTex;
+    vNormal = mat3(normalMatrix) * normalTex;
 }

--- a/data/shaders/terrain.vert
+++ b/data/shaders/terrain.vert
@@ -26,10 +26,10 @@ void main()
 {
     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
     vViewPosition = -mvPosition.xyz;
-    vNormal = normalize(vec3(normalMatrix * vec4(normal, 1.0)));
+    vNormal = normalize(vec3(normalMatrix) * normal);
 
     // tangent and binormal vectors
-    vTangent = normalize(vec3(normalMatrix * vec4(tangent, 1.0)));
+    vTangent = normalize(vec3(normalMatrix) * tangent);
     vBinormal = cross( vNormal, vTangent );
     vBinormal = normalize( vBinormal );
 
@@ -43,5 +43,5 @@ void main()
     gl_Position = projectionMatrix * displacedPosition;
 
     vec3 normalTex = texture2D(tNormal, uv).xyz * 2.0 - 1.0;
-    vNormal = vec3(normalMatrix * vec4(normalTex, 1.0));
+    vNormal = vec3(normalMatrix) * normalTex;
 }

--- a/data/shaders/terrain.vert
+++ b/data/shaders/terrain.vert
@@ -26,10 +26,10 @@ void main()
 {
     vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
     vViewPosition = -mvPosition.xyz;
-    vNormal = normalize(vec3(normalMatrix) * normal);
+    vNormal = normalize(normalMatrix * normal);
 
     // tangent and binormal vectors
-    vTangent = normalize(vec3(normalMatrix) * tangent);
+    vTangent = normalize(normalMatrix * tangent);
     vBinormal = cross( vNormal, vTangent );
     vBinormal = normalize( vBinormal );
 
@@ -43,5 +43,5 @@ void main()
     gl_Position = projectionMatrix * displacedPosition;
 
     vec3 normalTex = texture2D(tNormal, uv).xyz * 2.0 - 1.0;
-    vNormal = vec3(normalMatrix) * normalTex;
+    vNormal = normalMatrix * normalTex;
 }

--- a/meson.build
+++ b/meson.build
@@ -47,7 +47,23 @@ if need_win32 and (need_x11 or need_gbm or need_drm or need_wayland or need_disp
 endif
 
 if need_x11
-    x11_dep = dependency('x11')
+    if host_machine.system() == 'darwin'
+        # On macOS, use XQuartz's X11 and GL libraries for GLX support
+        x11_dep = declare_dependency(
+            compile_args: ['-I/opt/X11/include'],
+            link_args: ['-L/opt/X11/lib', '-lX11'],
+        )
+        # XQuartz provides libGL with GLX support
+        opengl_dep = declare_dependency(
+            link_args: ['-L/opt/X11/lib'],
+        )
+        add_global_arguments('-DGLMARK2_USE_APPLE_OPENGL', language : 'cpp')
+    else
+        x11_dep = dependency('x11')
+        opengl_dep = declare_dependency()
+    endif
+else
+    opengl_dep = declare_dependency()
 endif
 
 if need_drm

--- a/src/gl-state-glx.cpp
+++ b/src/gl-state-glx.cpp
@@ -418,21 +418,15 @@ GLStateGLX::load_proc(void *userptr, const char* name)
 {
     GLStateGLX* state = reinterpret_cast<GLStateGLX*>(userptr);
     
-    // First try to load from the library directly (for bootstrap and fallback)
-    GLADapiproc sym = reinterpret_cast<GLADapiproc>(state->lib_.load(name));
-    if (sym) {
-        return sym;
-    }
-    Log::debug("Symbol %s not in library, trying glXGetProcAddress\n", name);
-    
-    // If available, also try glXGetProcAddress for extension functions
+    // Try glXGetProcAddress first for extension functions (standard GLX pattern)
     if (glXGetProcAddress) {
         const GLubyte* bytes = reinterpret_cast<const GLubyte*>(name);
-        sym = glXGetProcAddress(bytes);
+        GLADapiproc sym = glXGetProcAddress(bytes);
         if (sym) {
             return sym;
         }
     }
-
-    return nullptr;
+    
+    // Fall back to direct library loading for bootstrap and core functions
+    return reinterpret_cast<GLADapiproc>(state->lib_.load(name));
 }

--- a/src/gl-state-glx.cpp
+++ b/src/gl-state-glx.cpp
@@ -420,12 +420,10 @@ GLStateGLX::load_proc(void *userptr, const char* name)
     
     // First try to load from the library directly (for bootstrap and fallback)
     GLADapiproc sym = reinterpret_cast<GLADapiproc>(state->lib_.load(name));
-    if (!sym) {
-        Log::debug("Failed to load symbol: %s\n", name);
-    }
     if (sym) {
         return sym;
     }
+    Log::debug("Symbol %s not in library, trying glXGetProcAddress\n", name);
     
     // If available, also try glXGetProcAddress for extension functions
     if (glXGetProcAddress) {

--- a/src/gl-state-glx.cpp
+++ b/src/gl-state-glx.cpp
@@ -47,6 +47,15 @@ GLStateGLX::init_display(void* native_display, GLVisualConfig& visual_config)
         Log::error("Failed to load libGL from XQuartz\n");
         return false;
     }
+    Log::debug("Successfully loaded libGL library\n");
+    
+    // Test if we can load a basic GLX function
+    void* test_func = lib_.load("glXQueryVersion");
+    if (!test_func) {
+        Log::error("Failed to load glXQueryVersion from libGL\n");
+        return false;
+    }
+    Log::debug("Successfully loaded glXQueryVersion test function\n");
 #else
     if (!lib_.open_from_alternatives({"libGL.so", "libGL.so.1"})) {
         Log::error("Failed to load libGL\n");
@@ -60,8 +69,21 @@ GLStateGLX::init_display(void* native_display, GLVisualConfig& visual_config)
     }
     
     int screen = DefaultScreen(xdpy_);
+    Log::debug("Display: %p, Screen: %d\n", xdpy_, screen);
+    
+    // Try to manually load and call glXQueryVersion as a test
+    typedef Bool (*glXQueryVersionProc)(Display*, int*, int*);
+    glXQueryVersionProc queryVersion = reinterpret_cast<glXQueryVersionProc>(lib_.load("glXQueryVersion"));
+    if (queryVersion) {
+        int major, minor;
+        Bool result = queryVersion(xdpy_, &major, &minor);
+        Log::debug("Manual glXQueryVersion result: %d, version: %d.%d\n", result, major, minor);
+    } else {
+        Log::debug("Could not load glXQueryVersion manually\n");
+    }
     
     int glx_loaded = gladLoadGLXUserPtr(xdpy_, screen, load_proc, this);
+    Log::debug("gladLoadGLXUserPtr returned: %d\n", glx_loaded);
     if (glx_loaded == 0) {
         Log::error("Failed to load GLX functions\n");
         return false;
@@ -396,15 +418,21 @@ GLStateGLX::load_proc(void *userptr, const char* name)
 {
     GLStateGLX* state = reinterpret_cast<GLStateGLX*>(userptr);
     
-    // Try glXGetProcAddress first for extension functions (standard GLX pattern)
+    // First try to load from the library directly (for bootstrap and fallback)
+    GLADapiproc sym = reinterpret_cast<GLADapiproc>(state->lib_.load(name));
+    if (sym) {
+        return sym;
+    }
+    Log::debug("Symbol %s not in library, trying glXGetProcAddress\n", name);
+    
+    // If available, also try glXGetProcAddress for extension functions
     if (glXGetProcAddress) {
         const GLubyte* bytes = reinterpret_cast<const GLubyte*>(name);
-        GLADapiproc sym = glXGetProcAddress(bytes);
+        sym = glXGetProcAddress(bytes);
         if (sym) {
             return sym;
         }
     }
-    
-    // Fall back to direct library loading for bootstrap and core functions
-    return reinterpret_cast<GLADapiproc>(state->lib_.load(name));
+
+    return nullptr;
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -299,7 +299,7 @@ if need_glx
     # and parity with gl-state-egl.
     wsi_glx_dep = declare_dependency(
         sources: ['gl-state-glx.cpp', 'glad/src/glx.c'],
-        dependencies: x11_dep,
+        dependencies: [x11_dep, opengl_dep],
         include_directories: [
             include_directories('glad/include'),
             include_directories('libmatrix'),

--- a/src/shared-library.cpp
+++ b/src/shared-library.cpp
@@ -44,9 +44,12 @@ bool SharedLibrary::open(const char *libName)
 #if defined(WIN32)
     handle_ = LoadLibraryA(libName);
 #else
-    // On macOS with nullptr, use dlopen(NULL, ...) to search the global symbol table
-    // NULL opens the main program and all loaded libraries
+    // On macOS, RTLD_GLOBAL may be needed for symbol resolution
+#ifdef __APPLE__
     handle_ = dlopen(libName, RTLD_NOW | RTLD_NODELETE | RTLD_GLOBAL);
+#else
+    handle_ = dlopen(libName, RTLD_NOW | RTLD_NODELETE);
+#endif
 #endif
     return (handle_ != nullptr);
 }

--- a/src/shared-library.cpp
+++ b/src/shared-library.cpp
@@ -44,7 +44,9 @@ bool SharedLibrary::open(const char *libName)
 #if defined(WIN32)
     handle_ = LoadLibraryA(libName);
 #else
-    handle_ = dlopen(libName, RTLD_NOW | RTLD_NODELETE);
+    // On macOS with nullptr, use dlopen(NULL, ...) to search the global symbol table
+    // NULL opens the main program and all loaded libraries
+    handle_ = dlopen(libName, RTLD_NOW | RTLD_NODELETE | RTLD_GLOBAL);
 #endif
     return (handle_ != nullptr);
 }


### PR DESCRIPTION
## Cross-platform improvements: CI automation, Windows/macOS support, and GLSL fixes

### Summary
This PR adds comprehensive CI/CD automation for Windows and macOS builds, improves cross-platform compatibility, and fixes GLSL shader bugs that affected strict compilers and shader translation layers.

### Changes Overview

#### 1. CI/CD Infrastructure Updates
- **Updated GitHub Actions** to latest versions for better security and performance
- **Upgraded runners**: Ubuntu 20.04 → 22.04, Windows 2019 → 2022
- **Added manual workflow triggers** for on-demand builds
- **Implemented artifact generation** for Linux, Windows, and macOS builds
- **Added automated release job** that creates GitHub releases on workflow dispatch

#### 2. macOS Support (commits c67c340 through b404cca)
- **Added XQuartz/X11 support** for OpenGL on macOS
- **Implemented dual-architecture builds**: ARM64 (Apple Silicon) and Intel x86_64
- **Dynamic library bundling**: libjpeg-turbo and libpng are bundled with binaries for portability
- **Set appropriate deployment targets**: macOS 10.15+ (Catalina) for x86_64, macOS 11.0+ for ARM64
- **Fixed artifact creation** using proper GitHub workspace paths
- **Added installation instructions** with `xattr` commands to remove quarantine flags

#### 3. GLSL Shader Fixes (commits 2f19756 and 62943b6)

**Problem**: The original code incorrectly multiplied `mat3` with `vec4`:
```glsl
vec3 N = normalize(vec3(NormalMatrix * vec4(normal, 1.0)));
```

**Issues**:
- `mat3 * vec4` is invalid - a 3×3 matrix cannot multiply a 4-component vector
- Normals are direction vectors and don't need homogeneous coordinates

**Solution**: Changed to correct pattern:
```glsl
vec3 N = normalize(NormalMatrix * normal);
```

**Impact**: Fixed 14 instances across 10 shader files:
- bump-height.vert (3 instances: normal, tangent, bitangent)
- bump-normals.frag
- bump-poly.vert
- light-advanced.vert
- light-basic-texgen.vert
- light-basic.vert
- light-phong.vert
- light-refract.vert
- pulsar-light.vert
- terrain.vert (3 instances)

### Files Modified
- build.yml - CI/CD pipeline with macOS/Windows builds
- meson.build - Build configuration updates
- gl-state-glx.cpp, gl-state-glx.h - GLX state management
- `data/shaders/*.vert`, `data/shaders/*.frag` - GLSL shader fixes

### Testing
- ✅ Linux builds (Ubuntu 22.04) pass CI
- ✅ Windows builds (windows-2022) pass CI
- ✅ macOS ARM64 builds succeed
- ✅ macOS Intel x86_64 builds succeed
- ✅ Shaders compile correctly on all platforms
- ✅ XQuartz/GLX with Metal translation works on macOS
- ✅ Bundled libraries work correctly on macOS

### Benefits
1. **Automated builds** for all major platforms
2. **Portable macOS binaries** with bundled dependencies
3. **GLSL compliance** improves portability across OpenGL implementations
4. **Automated releases** streamline distribution process

### Backward Compatibility
All changes are backward compatible. The GLSL fixes improve correctness without changing rendering behavior.